### PR TITLE
Enable logging at the ApiGateway level to allow for auditing

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -69,6 +69,10 @@ provider:
         - !GetAtt FHIRBinaryBucket.Arn
         - !Join ['', [!GetAtt FHIRBinaryBucket.Arn, '/*']]
   variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._@'\",\\-\\/\\(\\)]+?)}" # Use this for allowing CloudFormation Pseudo-Parameters in your serverless.yml
+  logs:
+    restApi:
+      executionLogging: true
+      fullExecutionData: true
 
 functions:
   fhirServer:


### PR DESCRIPTION
Enable logging at the ApiGateway level to allow for auditing. This will log the full request and response passing through ApiGateway.

API Docs: https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.