### PR TITLE
Adjusting ES Alarm to prevent transient alarming

### DIFF
--- a/cloudformation/alarms.yaml
+++ b/cloudformation/alarms.yaml
@@ -130,7 +130,8 @@ Resources:
           Value: !Ref 'AWS::AccountId'
         - Name: DomainName
           Value: !Ref ElasticSearchDomain
-      EvaluationPeriods: 1
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 3
       MetricName: 'ClusterStatus.red'
       Namespace: 'AWS/ES'
       Period: 60


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: ES.red alarm does occur transiently and should only be investigated if it is constant. This change makes the alarm 3/5 instead of 1/1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.