### PR TITLE
Remove Hearth interface from sample configs

### DIFF
--- a/sampleData/r3FhirConfigWithExclusions.ts
+++ b/sampleData/r3FhirConfigWithExclusions.ts
@@ -1,4 +1,6 @@
-const config: Hearth.FhirConfig = {
+import { FhirConfig } from '../src/interface/fhirConfig';
+
+const config: FhirConfig = {
     orgName: 'Organization Name',
     auth: {
         strategy: {

--- a/sampleData/r4FhirConfigGeneric.ts
+++ b/sampleData/r4FhirConfigGeneric.ts
@@ -1,4 +1,6 @@
-const config: Hearth.FhirConfig = {
+import { FhirConfig } from '../src/interface/fhirConfig';
+
+const config: FhirConfig = {
     orgName: 'Organization Name',
     auth: {
         strategy: {

--- a/sampleData/r4FhirConfigNoGeneric.ts
+++ b/sampleData/r4FhirConfigNoGeneric.ts
@@ -1,4 +1,6 @@
-const config: Hearth.FhirConfig = {
+import { FhirConfig } from '../src/interface/fhirConfig';
+
+const config: FhirConfig = {
     orgName: 'Organization Name',
     auth: {
         strategy: {

--- a/sampleData/r4FhirConfigWithExclusions.ts
+++ b/sampleData/r4FhirConfigWithExclusions.ts
@@ -1,4 +1,6 @@
-const config: Hearth.FhirConfig = {
+import { FhirConfig } from '../src/interface/fhirConfig';
+
+const config: FhirConfig = {
     orgName: 'Organization Name',
     auth: {
         strategy: {


### PR DESCRIPTION
Remove Hearth interface from sample configs

This will hopefully resolve this failing test in code pipeline
```
FAIL src/router/metadata/metadataHandler.test.ts

  ● Test suite failed to run
    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    ·[96msampleData/r4FhirConfigGeneric.ts·[0m:·[93m1·[0m:·[93m15·[0m - ·[91merror·[0m·[90m TS2503: ·[0mCannot find namespace 'Hearth'.
    ·[7m1·[0m const config: Hearth.FhirConfig = {
    ·[7m ·[0m ·[91m              ~~~~~~·[0m
```