### PR TITLE
Fix count value returned for ESResponse

### DIFF
--- a/src/search/elasticSearchService.ts
+++ b/src/search/elasticSearchService.ts
@@ -64,7 +64,7 @@ const ElasticSearchService: Search = class {
             };
 
             const response = await ElasticSearch.search(params);
-            const total = response.body.hits.total.value;
+            const total = response.body.hits.hits.length;
 
             const result: SearchResult = {
                 numberOfResults: total,


### PR DESCRIPTION
`response.body.hits.total.value` doesn't return an accurate number of count when we the search query include the size `param`. 
Using the length of `hits` instead. 