### PR TITLE
Only allow one depoyment at a time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,12 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
-
       - name: Install dependencies
         run: |
           cd auditLogMover
@@ -30,8 +28,19 @@ jobs:
           yarn lint
       - name: Unit tests
         run: yarn test
-  deploy:
+  pre-deployment-check:
     needs: unit-test
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    steps:
+      - name: 'Block Concurrent Deployments'
+        uses: softprops/turnstyle@v1
+        with:
+          poll-interval-seconds: 10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  deploy:
+    needs: pre-deployment-check
     name: Deploy to Dev
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
This Github action sets up a queue for deployments to the test environment.
https://github.com/softprops/turnstyle

Currently I set it, so that the max time it'll wait before cancelling the deployment is 10 minutes. The last [deployment](https://github.com/awslabs/aws-fhir-solution/actions/runs/164903404) took about 7 minutes.

Sources
https://github.community/t/how-to-limit-concurrent-workflow-runs/16844/22

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.