### PR TITLE
[ddbToEs] Process LATEST records and limit number of retries

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -123,9 +123,8 @@ functions:
               - ResourceDynamoDBTable
               - StreamArn
           batchSize: 100
-          maximumRetryAttempts: 2
+          maximumRetryAttempts: 3
           startingPosition: LATEST
-          maximumRecordAgeInSeconds: 120
 
 resources:
   - Conditions:


### PR DESCRIPTION
This PR attempts to prevent our lambda function for repeatedly retrying requests from DDB that are no longer valid. 
* Setting startingPosition to LATEST so we read the latest records instead of the oldest records in the shard. [link](https://stackoverflow.com/questions/38280958/dynamodb-triggers-streams-lambda-details-on-trim-horizon)
* If a lambda stream fails we should limit the number of retries, and the age of records we are processing. [link](https://www.serverless.com/framework/docs/providers/aws/events/streams/)
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.