### PR TITLE
On passing of crucible tests, merge develop branch to mainline branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,7 @@ jobs:
           serverless deploy --stage dev --region us-west-2 --conceal
   crucible-test:
     needs: deploy
+    name: Run Crucible Tests
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -98,3 +99,16 @@ jobs:
           --auth-flow USER_PASSWORD_AUTH --auth-parameters USERNAME=workshopuser,PASSWORD=Master123! | \
           python -c 'import json,sys;obj=json.load(sys.stdin);print obj["AuthenticationResult"]["AccessToken"]')
           bundle exec rake crucible:execute_hearth_tests[$SERVICE_URL,$API_KEY,$ACCESS_TOKEN]
+  merge-develop-to-mainline:
+    needs: crucible-test
+    name: Merge develop to mainline
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Merge to mainline branch
+      uses: devmasx/merge-branch@v1.1.0
+      with:
+        type: now
+        target_branch: 'mainline'
+      env:
+        GITHUB_TOKEN: ${{secrets.MERGE_TOKEN}}


### PR DESCRIPTION
On passing of crucible tests, merge develop branch to master branch.

Testing:
I created a public repo in my account to tests the change here. In my account I have a `mainline` branch and a `develop` branch. The `mainline` branch in my public is set up with PR status check protection just like our repo.  Examples below shows what the commit history looks like for `develop` branch and `mainline` branch.

<img width="1319" alt="develop-branch" src="https://user-images.githubusercontent.com/3661906/87585648-65560700-c6ad-11ea-8d47-91e4bd567b84.png">


<img width="1330" alt="mainline-branch" src="https://user-images.githubusercontent.com/3661906/87585657-6850f780-c6ad-11ea-99e1-e94565c7776f.png">

**Note:** The commit history of `mainline` will include an additional commit saying `Merge <git-sha> into mainline`. That is an additional commit created by Github actions when merging `develop` into `mainline`. 