### PR TITLE
Moving the shebang to the top of the shell script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,10 @@
-__='
-   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-   SPDX-License-Identifier: Apache-2.0
-'
-
 #!/bin/bash
+
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
 #Usage: ./install.sh <OPTIONAL PARAMETERS>
 
 #Bugs:


### PR DESCRIPTION
Description of changes:
- Install script won't work unless the shebang is on line 1.

Tests:
- Ran install.sh

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.