### PR TITLE
Add missing dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14.4
 
 # Required dependencies
-RUN apt-get update && apt-get install -yq python3-pip && pip3 install boto3 && curl -fsSL --compressed  "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install && npm install serverless -g
+RUN apt-get update && apt-get install -yq python3-pip less dnsutils && pip3 install boto3 && curl -fsSL --compressed  "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install && npm install serverless -g
 
 WORKDIR /home/node
 


### PR DESCRIPTION
Issue #, if available:

### Description of changes:
`less` required by AWS CLI
`nslookup` provided by `dnsutils`
`boto3` required by Python scripts


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.