### PR TITLE
Fix deploy github workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -71,11 +71,10 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn install
           serverless deploy --stage dev --region us-west-2 --conceal
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Deploy auditLogMover
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID}}


### PR DESCRIPTION
Description of changes:
the `env ` key was used twice, making the workflow file invalid https://github.com/awslabs/aws-fhir-solution/actions/runs/218594909. This fixes it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
