### PR TITLE
Fix git clone to use correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Clone or download the repository to a local directory. **Note:** if you intend t
 Git Clone example:
 
 ```sh
-git clone https://github.com/fhir-works-on-aws-deployment.git
+git clone https://github.com/awslabs/fhir-works-on-aws-deployment.git
 ```
 
 ### Install


### PR DESCRIPTION
Fix git clone example to add 'awslabs' to the URL

Issue #, if available:

Description of changes:


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
