### PR TITLE
Add permission for index to export-request table 

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -73,6 +73,10 @@ provider:
       Resource:
         - !GetAtt ResourceDynamoDBTable.Arn
         - !GetAtt ExportRequestDynamoDBTable.Arn
+    - Action:
+        - 'dynamodb:Query'
+      Effect: Allow
+      Resource:
         - !Join ['', [!GetAtt ExportRequestDynamoDBTable.Arn, '/index/*']]
     - Action:
         - 'es:*'

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -73,6 +73,7 @@ provider:
       Resource:
         - !GetAtt ResourceDynamoDBTable.Arn
         - !GetAtt ExportRequestDynamoDBTable.Arn
+        - !Join ['', [!GetAtt ExportRequestDynamoDBTable.Arn, '/index/*']]
     - Action:
         - 'es:*'
       Effect: Allow


### PR DESCRIPTION
Issue #, if available:

Description of changes:
We have an index in the `export-request` table called `jobStatus-index`. Let's add index access permission to our lambda function.

[Reference](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/api-permissions-reference.html)

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
