### PR TITLE
feat: add lambda fns to start glue jobs and check its status

### DIFF
--- a/bulkExport/index.ts
+++ b/bulkExport/index.ts
@@ -3,6 +3,8 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { startCrawlerHandler } from 'fhir-works-on-aws-persistence-ddb';
+import { startCrawlerHandler, startExportJobHandler, getJobStatusHandler } from 'fhir-works-on-aws-persistence-ddb';
 
 exports.startCrawlerHandler = startCrawlerHandler;
+exports.startExportJobHandler = startExportJobHandler;
+exports.getJobStatusHandler = getJobStatusHandler;

--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -118,7 +118,7 @@ Resources:
         Rules:
           - Id: ExpirationRule
             Status: Enabled
-            ExpirationInDays: '7'
+            ExpirationInDays: '3'
 
   GlueJobRole:
     Type: AWS::IAM::Role

--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -77,3 +77,96 @@ Resources:
                 Action:
                   - glue:StartCrawler
                 Resource: !Join ['', [!Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/', !Ref Crawler]]
+
+  GlueJobRelatedLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service: 'lambda.amazonaws.com'
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      Policies:
+        - PolicyName: glueAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - glue:StartJobRun
+                  - glue:GetJobRun
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - dynamodb:Query
+                  - dynamodb:GetItem
+                Resource:
+                  - !GetAtt ExportRequestDynamoDBTable.Arn
+
+  GlueScriptsBucket:
+    Type: AWS::S3::Bucket
+
+  BulkExportResultsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpirationRule
+            Status: Enabled
+            ExpirationInDays: '7'
+
+  GlueJobRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - glue.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+      Policies:
+        - PolicyName: ddbAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:DescribeTable
+                  - dynamodb:Scan
+                Resource: !GetAtt ResourceDynamoDBTableV2.Arn
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource:
+                  - !GetAtt DynamodbKMSKey.Arn
+        - PolicyName: s3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Join ['', ['arn:aws:s3:::', !Ref BulkExportResultsBucket,'/*']]
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: !Join ['', ['arn:aws:s3:::', !Ref GlueScriptsBucket,'/*']]
+
+  ExportGlueJob:
+    Type: AWS::Glue::Job # TODO: update this configuration once we have an actual ETL script
+    Properties:
+      Role: !GetAtt GlueJobRole.Arn
+      Command:
+        ScriptLocation: !Join ['', ['s3://', !Ref GlueScriptsBucket, '/our-glue-export-script.py']]
+        Name: glueetl
+        PythonVersion: '3'

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -163,6 +163,26 @@ functions:
     environment:
       CRAWLER_NAME: !Ref Crawler
 
+  startExportJob:
+    timeout: 30
+    memorySize: 192
+    runtime: nodejs12.x
+    description: 'Start the Glue job for bulk export'
+    role: GlueJobRelatedLambdaRole
+    handler: bulkExport/index.startExportJobHandler
+    environment:
+      GLUE_JOB_NAME: !Ref ExportGlueJob
+
+  getJobStatus:
+    timeout: 30
+    memorySize: 192
+    runtime: nodejs12.x
+    description: 'Get the status of a Glue job run for bulk export'
+    role: GlueJobRelatedLambdaRole
+    handler: bulkExport/index.getJobStatusHandler
+    environment:
+      GLUE_JOB_NAME: !Ref ExportGlueJob
+
 resources:
   - Conditions:
       isDev: !Equals ['${self:custom.stage}', 'dev']


### PR DESCRIPTION
Description of changes:

Add CFN resources to support the startExportJob and getJobStatus lambda functions.

ExportGlueJob and GlueJobRole may need some changes once we have the actual Glue script. For now i tested the permissions/config with the most basic script that's generated from the Glue console(pretty much just dump DDB to S3 as is)

Checklist:

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-persistence-ddb/pull/27

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
