### PR TITLE
fix: add missing step functions permissions

### DIFF
--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -138,3 +138,32 @@ Resources:
                 Action:
                   - s3:GetObject
                 Resource: !Join ['', [!GetAtt BulkExportResultsBucket.Arn, '/*']]
+
+  UpdateStatusLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service: 'lambda.amazonaws.com'
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      Policies:
+        - PolicyName: ddbAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:UpdateItem
+                Resource:
+                  - !GetAtt ExportRequestDynamoDBTable.Arn
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource:
+                  - !GetAtt DynamodbKMSKey.Arn

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -112,6 +112,11 @@ provider:
       Effect: Allow
       Resource:
         - !GetAtt ExportResultsSignerRole.Arn
+    - Action:
+        - 'states:StartExecution'
+      Effect: Allow
+      Resource:
+        - !Ref BulkExportStateMachine
   variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._@'\",\\-\\/\\(\\)]+?)}" # Use this for allowing CloudFormation Pseudo-Parameters in your serverless.yml
   logs:
     restApi:
@@ -151,8 +156,9 @@ functions:
           private: true
     handler: src/index.default
     provisionedConcurrency: 5
-    EXPORT_STATE_MACHINE_ARN:
-      Ref: BulkExportStateMachine
+    environment:
+      EXPORT_STATE_MACHINE_ARN:
+        Ref: BulkExportStateMachine
 
   ddbToEs:
     timeout: 300
@@ -206,6 +212,7 @@ functions:
     memorySize: 192
     runtime: nodejs12.x
     description: 'Update the status of a bulk export job'
+    role: UpdateStatusLambdaRole
     handler: bulkExport/index.updateStatusStatusHandler
 
 stepFunctions:


### PR DESCRIPTION
Description of changes:
Fix env variable and add permissions. 
Also created a separate `UpdateStatusLambdaRole` to break a circular dependency( and because it was the right thing to do to begin with)

btw, the `iamRoleStatements` in the `provider` section are added to ALL lambdas unless they provide their own role. That's probably not what we want since those permissions are specific to the `fhirServer` lambda. Still, not changing it right now since that refactor would cause even more conflicts with mainline.

Checklist:

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
