### PR TITLE
feat: upload glue scripts to s3 on deployment

### DIFF
--- a/bulkExport/uploadGlueScriptsToS3.ts
+++ b/bulkExport/uploadGlueScriptsToS3.ts
@@ -1,0 +1,64 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs';
+import * as AWS from 'aws-sdk';
+import axios from 'axios';
+
+const sendCfnResponse = async (event, status: 'SUCCESS' | 'FAILED', error?: Error) => {
+    const responseBody = JSON.stringify({
+        Status: status,
+        Reason: error?.message,
+        // The value of PhysicalResourceId doesn't really matter in this case.
+        // It just needs to be the same string on all responses to indicate that it is the same resource.
+        PhysicalResourceId: 'glueScripts',
+        StackId: event.StackId,
+        RequestId: event.RequestId,
+        LogicalResourceId: event.LogicalResourceId,
+    });
+    console.log(`Sending response to CFN: ${responseBody}`);
+    await axios.put(event.ResponseURL, responseBody);
+};
+/**
+ * Custom resource lambda handler that uploads a specific file to s3.
+ * Custom resource spec: See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html
+ * @param event Custom resource request event. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html
+ */
+exports.handler = async event => {
+    console.log(event);
+    try {
+        if (process.env.GLUE_SCRIPTS_BUCKET === undefined) {
+            throw new Error('Missing env variable GLUE_SCRIPTS_BUCKET');
+        }
+        const s3 = new AWS.S3();
+        const filename = 'export-script.py';
+        const path = `bulkExport/glueScripts/${filename}`;
+
+        if (event.RequestType === 'Create' || event.RequestType === 'Update') {
+            console.log(`uploading ${filename} to ${process.env.GLUE_SCRIPTS_BUCKET}`);
+            await s3
+                .putObject({
+                    Bucket: process.env.GLUE_SCRIPTS_BUCKET,
+                    Body: fs.readFileSync(path),
+                    Key: filename,
+                })
+                .promise();
+            console.log('upload successful');
+            await sendCfnResponse(event, 'SUCCESS');
+        } else {
+            console.log('Deleting files from s3');
+            await s3
+                .deleteObject({
+                    Bucket: process.env.GLUE_SCRIPTS_BUCKET,
+                    Key: filename,
+                })
+                .promise();
+            await sendCfnResponse(event, 'SUCCESS');
+        }
+    } catch (e) {
+        console.log(e);
+        await sendCfnResponse(event, 'FAILED', e);
+    }
+};

--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -97,9 +97,9 @@ Resources:
                 Resource: !Join ['', ['arn:aws:s3:::', !Ref GlueScriptsBucket,'/*']]
 
   ExportGlueJob:
-    Type: AWS::Glue::Job # TODO: update this configuration once we have an actual ETL script
+    Type: AWS::Glue::Job
+    DependsOn: UploadGlueScriptsCustomResource
     Properties:
-      DependsOn: UploadGlueScriptsCustomResource
       Role: !GetAtt GlueJobRole.Arn
       GlueVersion: '2.0'
       WorkerType: !Ref ExportGlueWorkerType

--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -167,3 +167,35 @@ Resources:
                   - kms:Decrypt
                 Resource:
                   - !GetAtt DynamodbKMSKey.Arn
+
+  UploadGlueScriptsCustomResource:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt UploadGlueScriptsLambdaFunction.Arn # serverless by convention capitalizes first letter and suffixes with "LambdaFunction"
+      RandomValue: ${sls:instanceId} # This forces the upload to happen on every deployment
+
+  UploadGlueScriptsLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      Policies:
+        - PolicyName: s3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource: !Join ['', ['arn:aws:s3:::', !Ref GlueScriptsBucket,'/*']]

--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -99,6 +99,7 @@ Resources:
   ExportGlueJob:
     Type: AWS::Glue::Job # TODO: update this configuration once we have an actual ETL script
     Properties:
+      DependsOn: UploadGlueScriptsCustomResource
       Role: !GetAtt GlueJobRole.Arn
       GlueVersion: '2.0'
       WorkerType: !Ref ExportGlueWorkerType

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "local": "node ."
   },
   "dependencies": {
+    "aws-sdk": "^2.785.0",
+    "axios": "^0.21.0",
     "fhir-works-on-aws-authz-rbac": "2.0.0",
     "fhir-works-on-aws-interface": "2.0.0",
     "fhir-works-on-aws-persistence-ddb": "2.0.1",

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -5,6 +5,10 @@
 
 service: fhir-service
 
+package:
+  include:
+    - bulkExport/glueScripts/export-script.py
+
 custom:
   oldResourceTableName: 'resource-${self:custom.stage}'
   resourceTableName: 'resource-db-${self:custom.stage}'
@@ -214,6 +218,17 @@ functions:
     description: 'Update the status of a bulk export job'
     role: UpdateStatusLambdaRole
     handler: bulkExport/index.updateStatusStatusHandler
+
+  uploadGlueScripts:
+    timeout: 30
+    memorySize: 192
+    runtime: nodejs12.x
+    description: 'Upload glue scripts to s3'
+    role: UploadGlueScriptsLambdaRole
+    handler: bulkExport/uploadGlueScriptsToS3.handler
+    disableLogs: true # needed to avoid race condition error "Resource of type 'AWS::Logs::LogGroup' already exists" since the custom resource lambda invocation may create the log group before CFN does
+    environment:
+      GLUE_SCRIPTS_BUCKET: !Ref GlueScriptsBucket
 
 stepFunctions:
   stateMachines:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1960,6 +1960,21 @@ aws-sdk@^2.697.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
+aws-sdk@^2.785.0:
+  version "2.785.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.785.0.tgz#e403dc92c87c00c9eda86b4214870d874ea69251"
+  integrity sha512-B8KOd9pg+ofT++O0D8rfm30VDdCzBWCFl43rvXBEWbH6lq/fQcLYLTbhKEufqjqnpwzT+prlpNszdNqKYME34g==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -2019,6 +2034,13 @@ axios@^0.19.2:
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
+
+axios@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
+  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
+  dependencies:
+    follow-redirects "^1.10.0"
 
 babel-jest@^25.5.1:
   version "25.5.1"
@@ -4294,6 +4316,11 @@ follow-redirects@1.5.10:
   integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
+
+follow-redirects@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Description of changes:
Add a custom resource to upload glue scripts to s3 as part of the CFN deployment. 

Checklist:
* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
