### PR TITLE
fix: Only merge develop to mainline if custom-integration-tests passes.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -134,7 +134,7 @@ jobs:
         run: yarn int-test
 
   merge-develop-to-mainline:
-    needs: crucible-test
+    needs: custom-integration-tests
     name: Merge develop to mainline
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Only merge `develop` to `mainline` if `custom-integration-tests` passes. `custom-integration-tests` only runs if `crucible-test `passes.

