### PR TITLE
chore: remove non-inclusive terminology from serverless.yaml description

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -233,7 +233,7 @@ stepFunctions:
       ${file(bulkExport/state-machine-definition.yaml)}
 
 resources:
-  - Description: (SO0128) - Solution - Master Template - This template creates all the necessary resources to deploy FHIR Works on AWS; a framework to deploy a FHIR server on AWS.
+  - Description: (SO0128) - Solution - Primary Template - This template creates all the necessary resources to deploy FHIR Works on AWS; a framework to deploy a FHIR server on AWS.
   - Parameters:
       Stage:
         Type: String


### PR DESCRIPTION
Issue #, if available: FHIR-398

Description of changes: removed non-inclusive terminology from serverless.yaml description


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
