### PR TITLE
fix: 'oauth2' is already included in authorizationUrl

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -43,8 +43,8 @@ export const fhirConfig: FhirConfig = {
         strategy: {
             service: 'OAuth',
             oauth: {
-                authorizationUrl: `${OAuthUrl}/oauth2/authorize`,
-                tokenUrl: `${OAuthUrl}/oauth2/token`,
+                authorizationUrl: `${OAuthUrl}/authorize`,
+                tokenUrl: `${OAuthUrl}/token`,
             },
         },
     },


### PR DESCRIPTION
Issue #, if available:

Description of changes:

We don't need to include `oauth2` because it's already included in `authorizationUrl`. [Reference here](https://github.com/awslabs/fhir-works-on-aws-deployment/blob/mainline/serverless.yaml#L43)

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
