### PR TITLE
fix: Requesters don't need to authenticate before hitting metadata url

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -155,6 +155,9 @@ functions:
           method: ANY
           path: '{proxy+}'
           private: true
+      - http:
+          method: GET
+          path: /metadata
     handler: src/index.default
     provisionedConcurrency: 5
     environment:


### PR DESCRIPTION
Issue #, if available:
FHIR-303

Description of changes:
Requesters don't need to authenticate before hitting metadata url.

The `metadata` route no longer have to go through COGNITO.

I tested hitting `metadata` route without any `auth`, and it worked as expected. I also ran the `crucible` tests and the tests still pass.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
