### PR TITLE
docs: Add troubleshooting tip for Fedora 32 machine

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -478,3 +478,9 @@ Then serverless has generated an invalid Cloudformation template.
 
 If you still get the same error after following the steps above, try removing the `fhir-works-on-aws-deployment` repository and downloading it again. Then proceed from step 2.
 
+- During installation if you're on a Linux machine and using Docker 
+
+If Docker is erroring out while running `apt-get`, it might be because it's unable to reach the Debian server to get software updates. Try running the build command with `--network=host`.
+Run `docker build -t fhir-server-install --network=host -f docker/Dockerfile .` 
+
+Note: This issue was seen on a Fedora 32 machine. 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Updated troubleshooting section of `INSTALL.md` doc. This is based on install issue seen on a Fedora 32 system using Docker for installation.
https://github.com/awslabs/fhir-works-on-aws-deployment/issues/162

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
