### PR TITLE
fix: cloud9 documentation and install script

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,6 @@ This installation guide covers a basic installation on Windows, Unix-like system
 In a Terminal application or command shell, navigate to the directory containing the package’s code.
 
 Configure your AWS Credentials:
-
 ```
 aws configure
 ```
@@ -63,7 +62,6 @@ sudo -E ./scripts/install.sh
 ```
 
 If you are using AWS Named Profiles, please use the `AWS_PROFILE` environment variable to set it, and use the `-E` sudo flag :
-
 ```sh
 export AWS_PROFILE=myprofile
 sudo -E ./scripts/install.sh
@@ -74,7 +72,6 @@ sudo -E ./scripts/install.sh
 Open Windows PowerShell for AWS as Administrator, and navigate to the directory containing the package's code.
 
 Configure your AWS Credentials:
-
 ```
 Initialize-AWSDefaultConfiguration -AccessKey <aws_access_key_id> -SecretKey <aws_secret_access_key> -ProfileLocation $HOME\.aws\credentials"
 ```
@@ -88,7 +85,7 @@ Set-ExecutionPolicy RemoteSigned
 .\scripts\win_install.ps1
 ```
 
-`Set-ExecutionPolicy RemoteSigned` is used to make the script executable on your machine. In the event this command cannot be executed (this often happens on managed computers), you can still try to execute `.\scripts\win_install.ps1`, as your computer may already be set up to allow the script to be executed. If this fails, you can install using Docker, install in the cloud via EC2 or Cloud9 (running Amazon Linux 2 or Ubuntu), or install manually.
+`Set-ExecutionPolicy RemoteSigned` is used to make the script executable on your machine. In the event this command cannot be executed (this often happens on managed computers), you can still try to execute `.\scripts\win_install.ps1`, as your computer may already be set up to allow the script to be executed. If this fails, you can install using Docker, install in the cloud via EC2 (running Amazon Linux 2) or Cloud9 (running Amazon Linux 2 or Ubuntu), or install manually.
 
 Follow the directions in the script to finish installation. See the Optional Installation Configurations section for more details.
 
@@ -103,7 +100,6 @@ The `stage` and `region` values are set by default to `dev` and `us-west-2`, but
 Install Docker (if you do not have it already) by following instructions on https://docs.docker.com/get-docker/
 
 Configure your AWS Credentials:
-
 ```
 aws configure
 ```
@@ -146,7 +142,14 @@ docker rm ${container_id}
 - Installation can fail if your computer already possesses an installation of Python 3 earlier than version 3.3.x.
 - Linux installation has only been tested on CentOS and Ubuntu (version 18). Other Linux distributions may not work properly, and will likely require manual installation of dependencies.
 - Windows installation has been tested when run from Windows PowerShell for AWS. Running the install script from a regular PowerShell may fail.
-- Cloud9 installation may fail (when using Amazon Linux 2 instance) with the following error message
+- Cloud9 installation may fail (when using Amazon Linux 2 instance) with the following error message:
+
+```
+Error: Package: 1:npm-3.10.10-1.6.17.1.1.el7.x86_64 (@epel)
+           Requires: nodejs = 1:6.17.1-1.el7
+(additional lines are omitted)
+```
+If you encounter this error run `sudo yum erase npm` and then re-run installation script.
 
 ## Manual installation prerequisites
 
@@ -471,24 +474,21 @@ S3 bucket policies can only examine request headers. When we set the encryption 
 ```sh
 curl -v -T ${S3_UPLOAD_FILE} ${S3_PUT_URL} -H "x-amz-server-side-encryption: ${S3_SSEC_ALGORITHM}" -H "x-amz-server-side-encryption-aws-kms-key-id: ${KMS_SSEC_KEY}"
 ```
-
 ### Troubleshooting
-
 - During installation if you encounter this error
 
 `An error occurred: DynamodbKMSKey - Exception=[class software.amazon.awssdk.services.kms.model.MalformedPolicyDocumentException] ErrorCode=[MalformedPolicyDocumentException], ErrorMessage=[Policy contains a statement with one or more invalid principals.]`
 
-Then serverless has generated an invalid Cloudformation template.
-
-1. Check that `serverless_config.json` has the correct `IAMUserArn`. You can get the arn by running `$(aws sts get-caller-identity --query "Arn" --output text)`
-2. Go to your AWS account and delete the `fhir-service-<stage>` Cloudformation template if it exist.
-3. Run `sudo ./scripts/install.sh` again
+Then serverless has generated an invalid Cloudformation template. 
+  1. Check that `serverless_config.json` has the correct `IAMUserArn`. You can get the arn by running `$(aws sts get-caller-identity --query "Arn" --output text)`
+  2. Go to your AWS account and delete the `fhir-service-<stage>` Cloudformation template if it exist. 
+  3. Run `sudo ./scripts/install.sh` again 
 
 If you still get the same error after following the steps above, try removing the `fhir-works-on-aws-deployment` repository and downloading it again. Then proceed from step 2.
 
-- During installation if you're on a Linux machine and using Docker
+- During installation if you're on a Linux machine and using Docker 
 
 If Docker is erroring out while running `apt-get`, it might be because it's unable to reach the Debian server to get software updates. Try running the build command with `--network=host`.
-Run `docker build -t fhir-server-install --network=host -f docker/Dockerfile .`
+Run `docker build -t fhir-server-install --network=host -f docker/Dockerfile .` 
 
-Note: This issue was seen on a Fedora 32 machine.
+Note: This issue was seen on a Fedora 32 machine. 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,7 @@ This installation guide covers a basic installation on Windows, Unix-like system
 In a Terminal application or command shell, navigate to the directory containing the package’s code.
 
 Configure your AWS Credentials:
+
 ```
 aws configure
 ```
@@ -62,6 +63,7 @@ sudo -E ./scripts/install.sh
 ```
 
 If you are using AWS Named Profiles, please use the `AWS_PROFILE` environment variable to set it, and use the `-E` sudo flag :
+
 ```sh
 export AWS_PROFILE=myprofile
 sudo -E ./scripts/install.sh
@@ -72,6 +74,7 @@ sudo -E ./scripts/install.sh
 Open Windows PowerShell for AWS as Administrator, and navigate to the directory containing the package's code.
 
 Configure your AWS Credentials:
+
 ```
 Initialize-AWSDefaultConfiguration -AccessKey <aws_access_key_id> -SecretKey <aws_secret_access_key> -ProfileLocation $HOME\.aws\credentials"
 ```
@@ -85,7 +88,7 @@ Set-ExecutionPolicy RemoteSigned
 .\scripts\win_install.ps1
 ```
 
-`Set-ExecutionPolicy RemoteSigned` is used to make the script executable on your machine. In the event this command cannot be executed (this often happens on managed computers), you can still try to execute `.\scripts\win_install.ps1`, as your computer may already be set up to allow the script to be executed. If this fails, you can install using Docker, install in the cloud via EC2 or Cloud9, or install manually.
+`Set-ExecutionPolicy RemoteSigned` is used to make the script executable on your machine. In the event this command cannot be executed (this often happens on managed computers), you can still try to execute `.\scripts\win_install.ps1`, as your computer may already be set up to allow the script to be executed. If this fails, you can install using Docker, install in the cloud via EC2 or Cloud9 (running Amazon Linux 2 or Ubuntu), or install manually.
 
 Follow the directions in the script to finish installation. See the Optional Installation Configurations section for more details.
 
@@ -100,6 +103,7 @@ The `stage` and `region` values are set by default to `dev` and `us-west-2`, but
 Install Docker (if you do not have it already) by following instructions on https://docs.docker.com/get-docker/
 
 Configure your AWS Credentials:
+
 ```
 aws configure
 ```
@@ -142,6 +146,7 @@ docker rm ${container_id}
 - Installation can fail if your computer already possesses an installation of Python 3 earlier than version 3.3.x.
 - Linux installation has only been tested on CentOS and Ubuntu (version 18). Other Linux distributions may not work properly, and will likely require manual installation of dependencies.
 - Windows installation has been tested when run from Windows PowerShell for AWS. Running the install script from a regular PowerShell may fail.
+- Cloud9 installation may fail (when using Amazon Linux 2 instance) with the following error message
 
 ## Manual installation prerequisites
 
@@ -466,21 +471,24 @@ S3 bucket policies can only examine request headers. When we set the encryption 
 ```sh
 curl -v -T ${S3_UPLOAD_FILE} ${S3_PUT_URL} -H "x-amz-server-side-encryption: ${S3_SSEC_ALGORITHM}" -H "x-amz-server-side-encryption-aws-kms-key-id: ${KMS_SSEC_KEY}"
 ```
+
 ### Troubleshooting
+
 - During installation if you encounter this error
 
 `An error occurred: DynamodbKMSKey - Exception=[class software.amazon.awssdk.services.kms.model.MalformedPolicyDocumentException] ErrorCode=[MalformedPolicyDocumentException], ErrorMessage=[Policy contains a statement with one or more invalid principals.]`
 
-Then serverless has generated an invalid Cloudformation template. 
-  1. Check that `serverless_config.json` has the correct `IAMUserArn`. You can get the arn by running `$(aws sts get-caller-identity --query "Arn" --output text)`
-  2. Go to your AWS account and delete the `fhir-service-<stage>` Cloudformation template if it exist. 
-  3. Run `sudo ./scripts/install.sh` again 
+Then serverless has generated an invalid Cloudformation template.
+
+1. Check that `serverless_config.json` has the correct `IAMUserArn`. You can get the arn by running `$(aws sts get-caller-identity --query "Arn" --output text)`
+2. Go to your AWS account and delete the `fhir-service-<stage>` Cloudformation template if it exist.
+3. Run `sudo ./scripts/install.sh` again
 
 If you still get the same error after following the steps above, try removing the `fhir-works-on-aws-deployment` repository and downloading it again. Then proceed from step 2.
 
-- During installation if you're on a Linux machine and using Docker 
+- During installation if you're on a Linux machine and using Docker
 
 If Docker is erroring out while running `apt-get`, it might be because it's unable to reach the Debian server to get software updates. Try running the build command with `--network=host`.
-Run `docker build -t fhir-server-install --network=host -f docker/Dockerfile .` 
+Run `docker build -t fhir-server-install --network=host -f docker/Dockerfile .`
 
-Note: This issue was seen on a Fedora 32 machine. 
+Note: This issue was seen on a Fedora 32 machine.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 #
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -50,8 +50,8 @@ function install_dependencies(){
         # Identify kernel release
         KERNEL_RELEASE=$(uname -r)
         #Update package manager
-        sudo $PKG_MANAGER update -y
-        sudo $PKG_MANAGER upgrade -y
+        sudo $PKG_MANAGER update
+        sudo $PKG_MANAGER upgrade
 
         #Yarn depends on node version >= 12.0.0
         if [ "$basepkg" == "apt-get" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 #
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -50,8 +50,8 @@ function install_dependencies(){
         # Identify kernel release
         KERNEL_RELEASE=$(uname -r)
         #Update package manager
-        sudo $PKG_MANAGER update
-        sudo $PKG_MANAGER upgrade
+        sudo $PKG_MANAGER update -y
+        sudo $PKG_MANAGER upgrade -y
 
         #Yarn depends on node version >= 12.0.0
         if [ "$basepkg" == "apt-get" ]; then
@@ -92,25 +92,25 @@ function install_dependencies(){
 
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         #sudo -u $SUDO_USER removes brew's error message that brew should not be run as 'sudo'
-        type -a brew 2>&1 || ( echo "ERROR: brew is required to install packages." >&2 && return 1 )
+        type -a brew 2>&1 || { error_msg="ERROR: brew is required to install packages."; return 1; }
         sudo -u $SUDO_USER brew install node
         sudo -u $SUDO_USER brew install python
         sudo -u $SUDO_USER brew install yarn
         sudo pip3 install boto3
         sudo npm install -g serverless
     else
-        echo "ERROR: this install script is only supported on Linux or OSX."
+        error_msg="ERROR: this install script is only supported on Linux or OSX."
         return 1
     fi
 
     echo "" >&2
 
-    type -a node 2>&1 || ( echo "ERROR: package 'nodejs' failed to install." >&2 && return 1 )
-    type -a npm 2>&1 || ( echo "ERROR: package 'npm' failed to install." >&2 && return 1 )
-    type -a python3 2>&1 || ( echo "ERROR: package 'python3' failed to install." >&2 && return 1 )
-    type -a pip3 2>&1 || ( echo "ERROR: package 'python3-pip' failed to install." >&2 && return 1 )
-    type -a yarn 2>&1 || ( echo "ERROR: package 'yarn' failed to install." >&2 && return 1 )
-    type -a serverless 2>&1 || ( echo "ERROR: package 'serverless' failed to install." >&2 && return 1 )
+    type -a node 2>&1 || { error_msg="ERROR: package 'nodejs' failed to install."; return 1; }
+    type -a npm 2>&1 || { error_msg="ERROR: package 'npm' failed to install."; return 1; }
+    type -a python3 2>&1 || { error_msg="ERROR: package 'python3' failed to install."; return 1; }
+    type -a pip3 2>&1 || { error_msg="ERROR: package 'python3-pip' failed to install."; return 1; }
+    type -a yarn 2>&1 || { error_msg="ERROR: package 'yarn' failed to install."; return 1; }
+    type -a serverless 2>&1 || { error_msg="ERROR: package 'serverless' failed to install."; return 1; }
 
     return 0
 }
@@ -290,7 +290,7 @@ if [ "$DOCKER" != "true" ]; then
     install_dependencies
     result=$?
     if [ "$result" != "0" ]; then
-        echo "Error: Please use the correct script for Windows installation."
+        echo ${error_msg}
         exit 1
     fi
     echo "Done!"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
1. Provided workaround instructions to enable installation on Cloud9 instance running Amazon Linux 2
2. Fixed a bug in installation script: using `(` meant that commands enclosed in `()` were running in a sub-shell, so `return` commands were returning from sub-shell, not `install_dependencies()` function 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
