### PR TITLE
chore: remove extra Cognito param

### DIFF
--- a/cloudformation/cognito.yaml
+++ b/cloudformation/cognito.yaml
@@ -36,8 +36,8 @@ Resources:
       ClientName: !Sub '${AWS::StackName}-UserPool'
       UserPoolId: !Ref UserPool
       CallbackURLs:
-        - !Ref CognitoOAuthCallbackURL
-      DefaultRedirectURI: !Ref CognitoOAuthRedirectURL
+        - !Ref CognitoOAuthDefaultRedirectURL
+      DefaultRedirectURI: !Ref CognitoOAuthDefaultRedirectURL
       ExplicitAuthFlows:
         - ALLOW_USER_PASSWORD_AUTH
         - ALLOW_REFRESH_TOKEN_AUTH

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -16,7 +16,6 @@ custom:
   exportRequestTableJobStatusIndex: 'jobStatus-index'
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
-  oauthCallback: ${opt:oauthCallback, 'http://localhost'}
   oauthRedirect: ${opt:oauthRedirect, 'http://localhost'}
   config: ${file(serverless_config.json)}
 
@@ -167,14 +166,10 @@ resources:
         Type: String
         Default: ${self:custom.stage}
         Description: 'The deployment stage (e.g. dev, qa, prod). Default: dev'
-      CognitoOAuthCallbackURL:
-        Type: String
-        Default: ${self:custom.oauthCallback}
-        Description: 'Cognito OAuth callback URL used for User Pool. Default:  ${self:custom.oauthCallback}'
-      CognitoOAuthRedirectURL:
+      CognitoOAuthDefaultRedirectURL:
         Type: String
         Default: ${self:custom.oauthRedirect}
-        Description: 'Cognito OAuth redirect URL used for User Pool. Default:  ${self:custom.oauthRedirect}'
+        Description: "Cognito's default OAuth redirect URL used for User Pool. Default:  ${self:custom.oauthRedirect}"
       ExportGlueWorkerType:
         Type: String
         Default: 'G.2X'


### PR DESCRIPTION
Description of changes:
- Make installation easier, by removing an extra parameter
- The goal of the cognito userpoolclient is to have a default redirect url and to have that it must be in the list of callback urls - so instead of having the user put in the same url twice we just reuse it

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
