### PR TITLE
patch urijs

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   "resolutions": {
     "dot-prop": "^5.1.1",
     "bl": "^4.0.3",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "urijs": "1.19.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9224,10 +9224,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urijs@1.19.2:
-  version "1.19.2"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.2.tgz#f9be09f00c4c5134b7cb3cf475c1dd394526265a"
-  integrity sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==
+urijs@1.19.2, urijs@1.19.4:
+  version "1.19.4"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.4.tgz#3953d7dacd801336c17921ee8c5518b150cbf965"
+  integrity sha512-2YF/wdFu02Gsly/wyx+S/f5w/oCF0ihVSgK/Sn8fcY/ZYMYtqxgi03Vi3V7HqyQP8mj8xHMuNFTBIPufmPRdoA==
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Description of changes:

urijs has a vulnerability that was patched on 1.19.4. urijs is a transitive dependency brought by serverless-offline. Upgrading to serverless-offline 6.x would fix it but it has breaking changes that affect us.

https://github.com/medialize/URI.js/releases/tag/v1.19.4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
