### PR TITLE
chore: Update dockerfile used for building docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14.4
 
 # Required dependencies
-RUN apt-get update && apt-get install -yq python3-pip less dnsutils && pip3 install boto3 && curl -fsSL --compressed  "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install && npm install serverless -g
+RUN apt-get update && apt-get install -yq python3-pip less && pip3 install boto3 && curl -fsSL --compressed  "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install && npm install serverless -g
 
 WORKDIR /home/node
 
@@ -10,6 +10,7 @@ WORKDIR /home/node
 # Temporary use local copy
 RUN mkdir fhir-works-on-aws-deployment
 COPY ./ ./fhir-works-on-aws-deployment/
+RUN rm -rf ./fhir-works-on-aws-deployment/.build
 RUN chown -R node:node .
 RUN chmod 700 ./fhir-works-on-aws-deployment/scripts/install.sh
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Removed installing `dnsutil` as that is not needed
* `less` was not removed as it's required by AWS CLI. [More info here](https://github.com/aws/aws-cli/issues/5038)
*  Added `RUN rm -rf ./fhir-works-on-aws-deployment/.build`. If a user runs `sls` locally before building the docker image, the `.build` folder needs to be removed. 

I tested building the new docker image and using the image to deploy FHIR Works.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
