### PR TITLE
feat: support standard FHIR search parameters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
         '@typescript-eslint/no-useless-constructor': 'error',
         'no-empty-function': 'off',
         '@typescript-eslint/no-empty-function': 'error',
-        'import/no-extraneous-dependencies': ['error', {'devDependencies': ['**/*.test.ts']}],
+        'import/no-extraneous-dependencies': ['error', {'devDependencies': ['**/*.test.ts', 'integration-tests/*']}],
     },
     settings: {
         'import/resolver': {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.4.0] - 2021-01-13
+
+### Added
+- The capability statement returned by `/metadata` now includes the detail of all search parameters supported
+- Add support for the standard FHIR search parameters. Each FHIR resource type defines its own set of search parameters. i.e the search parameters for Patient can be found [here](https://www.hl7.org/fhir/patient.html#search)
+
 ## [2.3.0] - 2020-11-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - The capability statement returned by `/metadata` now includes the detail of all search parameters supported
 - Add support for the standard FHIR search parameters. Each FHIR resource type defines its own set of search parameters. i.e the search parameters for Patient can be found [here](https://www.hl7.org/fhir/patient.html#search)
+- Search requests using invalid search parameters now return an error instead of an empty result set
 
 ## [2.3.0] - 2020-11-20
 

--- a/bulkExport/glueScripts/export-script.py
+++ b/bulkExport/glueScripts/export-script.py
@@ -83,7 +83,7 @@ filtered_dates_resource_dyn_frame = Filter.apply(frame = filtered_dates_dyn_fram
 
 # Drop fields that are not needed
 print('Dropping fields that are not needed')
-data_source_cleaned_dyn_frame = DropFields.apply(frame = filtered_dates_resource_dyn_frame, paths = ['documentStatus', 'lockEndTs', 'vid'])
+data_source_cleaned_dyn_frame = DropFields.apply(frame = filtered_dates_resource_dyn_frame, paths = ['documentStatus', 'lockEndTs', 'vid', '_references'])
 
 def add_dup_resource_type(record):
     record["resourceTypeDup"] = record["resourceType"]

--- a/integration-tests/bulkExport.test.ts
+++ b/integration-tests/bulkExport.test.ts
@@ -2,55 +2,16 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
-import axios from 'axios';
-import AWS from 'aws-sdk';
 import BulkExportTestHelper, { ExportStatusOutput } from './bulkExportTestHelper';
+import { getFhirClient } from './utils';
 
 const FIVE_MINUTES_IN_MS = 5 * 60 * 1000;
-const { API_URL, API_KEY, API_AWS_REGION, COGNITO_USERNAME, COGNITO_PASSWORD, COGNITO_CLIENT_ID } = process.env;
 
 describe('Bulk Export', () => {
     let bulkExportTestHelper: BulkExportTestHelper;
 
     beforeAll(async () => {
-        if (API_URL === undefined) {
-            throw new Error('API_URL environment variable is not defined');
-        }
-        if (API_KEY === undefined) {
-            throw new Error('API_KEY environment variable is not defined');
-        }
-        if (API_AWS_REGION === undefined) {
-            throw new Error('API_AWS_REGION environment variable is not defined');
-        }
-        if (COGNITO_CLIENT_ID === undefined) {
-            throw new Error('COGNITO_CLIENT_ID environment variable is not defined');
-        }
-        if (COGNITO_USERNAME === undefined) {
-            throw new Error('COGNITO_USERNAME environment variable is not defined');
-        }
-        if (COGNITO_PASSWORD === undefined) {
-            throw new Error('COGNITO_PASSWORD environment variable is not defined');
-        }
-
-        AWS.config.update({ region: API_AWS_REGION });
-        const Cognito = new AWS.CognitoIdentityServiceProvider();
-
-        const authResponse = await Cognito.initiateAuth({
-            ClientId: COGNITO_CLIENT_ID,
-            AuthFlow: 'USER_PASSWORD_AUTH',
-            AuthParameters: {
-                USERNAME: COGNITO_USERNAME,
-                PASSWORD: COGNITO_PASSWORD,
-            },
-        }).promise();
-
-        const fhirUserAxios = axios.create({
-            headers: {
-                'x-api-key': API_KEY,
-                Authorization: `Bearer ${authResponse.AuthenticationResult!.AccessToken}`,
-            },
-            baseURL: API_URL,
-        });
+        const fhirUserAxios = await getFhirClient();
 
         bulkExportTestHelper = new BulkExportTestHelper(fhirUserAxios);
     });

--- a/integration-tests/search.test.ts
+++ b/integration-tests/search.test.ts
@@ -1,0 +1,87 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import { AxiosInstance } from 'axios';
+import waitForExpect from 'wait-for-expect';
+import { getFhirClient, randomPatient } from './utils';
+
+jest.setTimeout(60 * 1000);
+
+const expectResourceToBePartOfSearchResults = async (
+    client: AxiosInstance,
+    search: { url: string; params?: any },
+    resource: any,
+) => {
+    console.log('Searching with params:', search);
+    await expect(
+        (async () => {
+            return (
+                await client.get(search.url, {
+                    params: search.params,
+                })
+            ).data;
+        })(),
+    ).resolves.toMatchObject({
+        resourceType: 'Bundle',
+        entry: expect.arrayContaining([
+            expect.objectContaining({
+                resource,
+            }),
+        ]),
+    });
+};
+
+describe('search', () => {
+    let client: AxiosInstance;
+    beforeAll(async () => {
+        client = await getFhirClient();
+    });
+    test('search for various valid parameters', async () => {
+        const testPatient: ReturnType<typeof randomPatient> = (await client.post('Patient', randomPatient())).data;
+
+        // wait for the patient to be asynchronously written to ES
+        await waitForExpect(
+            expectResourceToBePartOfSearchResults.bind(
+                null,
+                client,
+                {
+                    url: 'Patient',
+                    params: {
+                        _id: testPatient.id,
+                    },
+                },
+                testPatient,
+            ),
+            20000,
+            3000,
+        );
+
+        const p = (params: any) => ({ url: 'Patient', params });
+        const testsParams = [
+            p({ 'address-city': testPatient.address[0].city }),
+            p({ 'address-country': testPatient.address[0].country }),
+            p({ 'address-postalcode': testPatient.address[0].postalCode }),
+            p({ family: testPatient.name[0].family }),
+            p({ given: testPatient.name[0].given[0] }),
+            p({ name: testPatient.name[0].given[0] }),
+            p({ name: testPatient.name[0].given[0] }),
+            p({ phone: testPatient.telecom.find(x => x.system === 'phone')!.value }),
+            p({ email: testPatient.telecom.find(x => x.system === 'email')!.value }),
+            p({ organization: testPatient.managingOrganization.reference }),
+        ];
+
+        // run tests serially for easier debugging and to avoid throttling
+        // eslint-disable-next-line no-restricted-syntax
+        for (const testParams of testsParams) {
+            // eslint-disable-next-line no-await-in-loop
+            await expectResourceToBePartOfSearchResults(client, testParams, testPatient);
+        }
+    });
+
+    test('invalid search parameter should fail with 400', async () => {
+        await expect(client.get('Patient', { params: { someInvalidSearchParam: 'someValue' } })).rejects.toMatchObject({
+            response: { status: 400 },
+        });
+    });
+});

--- a/integration-tests/search.test.ts
+++ b/integration-tests/search.test.ts
@@ -65,9 +65,10 @@ describe('search', () => {
             p({ family: testPatient.name[0].family }),
             p({ given: testPatient.name[0].given[0] }),
             p({ name: testPatient.name[0].given[0] }),
-            p({ name: testPatient.name[0].given[0] }),
+            p({ gender: testPatient.gender, _id: testPatient.id }), // gender alone is not unique enough to guarantee a match on the first page of search results
             p({ phone: testPatient.telecom.find(x => x.system === 'phone')!.value }),
             p({ email: testPatient.telecom.find(x => x.system === 'email')!.value }),
+            p({ telecom: testPatient.telecom.find(x => x.system === 'email')!.value }),
             p({ organization: testPatient.managingOrganization.reference }),
         ];
 

--- a/integration-tests/utils.ts
+++ b/integration-tests/utils.ts
@@ -1,0 +1,115 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as AWS from 'aws-sdk';
+import axios from 'axios';
+import { Chance } from 'chance';
+
+export const getFhirClient = async () => {
+    const { API_URL, API_KEY, API_AWS_REGION, COGNITO_USERNAME, COGNITO_PASSWORD, COGNITO_CLIENT_ID } = process.env;
+    if (API_URL === undefined) {
+        throw new Error('API_URL environment variable is not defined');
+    }
+    if (API_KEY === undefined) {
+        throw new Error('API_KEY environment variable is not defined');
+    }
+    if (API_AWS_REGION === undefined) {
+        throw new Error('API_AWS_REGION environment variable is not defined');
+    }
+    if (COGNITO_CLIENT_ID === undefined) {
+        throw new Error('COGNITO_CLIENT_ID environment variable is not defined');
+    }
+    if (COGNITO_USERNAME === undefined) {
+        throw new Error('COGNITO_USERNAME environment variable is not defined');
+    }
+    if (COGNITO_PASSWORD === undefined) {
+        throw new Error('COGNITO_PASSWORD environment variable is not defined');
+    }
+
+    AWS.config.update({ region: API_AWS_REGION });
+    const Cognito = new AWS.CognitoIdentityServiceProvider();
+
+    const authResponse = await Cognito.initiateAuth({
+        ClientId: COGNITO_CLIENT_ID,
+        AuthFlow: 'USER_PASSWORD_AUTH',
+        AuthParameters: {
+            USERNAME: COGNITO_USERNAME,
+            PASSWORD: COGNITO_PASSWORD,
+        },
+    }).promise();
+
+    return axios.create({
+        headers: {
+            'x-api-key': API_KEY,
+            Authorization: `Bearer ${authResponse.AuthenticationResult!.AccessToken}`,
+        },
+        baseURL: API_URL,
+    });
+};
+
+export const randomPatient = () => {
+    const chance = new Chance();
+    return {
+        id: chance.word({ length: 15 }),
+        resourceType: 'Patient',
+        active: true,
+        name: [
+            {
+                use: 'official',
+                family: chance.word({ length: 15 }),
+                given: [chance.word({ length: 15 }), chance.word({ length: 15 })],
+            },
+            {
+                use: 'maiden',
+                family: chance.word({ length: 15 }),
+                given: [chance.word({ length: 15 }), chance.word({ length: 15 })],
+                period: {
+                    end: '2002',
+                },
+            },
+        ],
+        telecom: [
+            {
+                system: 'phone',
+                value: chance.phone(),
+                use: 'work',
+                rank: 1,
+            },
+            {
+                system: 'phone',
+                value: chance.phone(),
+                use: 'mobile',
+                rank: 2,
+            },
+            {
+                system: 'email',
+                value: chance.email(),
+                use: 'home',
+            },
+        ],
+        gender: chance.pickone(['male', 'female']),
+        birthDate: '1974-12-25',
+        deceasedBoolean: false,
+        address: [
+            {
+                use: 'home',
+                type: 'both',
+                text: chance.word({ length: 15 }),
+                line: [chance.word({ length: 15 })],
+                city: chance.word({ length: 15 }),
+                district: chance.word({ length: 15 }),
+                state: chance.word({ length: 15 }),
+                postalCode: chance.word({ length: 15 }),
+                country: chance.word({ length: 15 }),
+                period: {
+                    start: '1974-12-25',
+                },
+            },
+        ],
+        managingOrganization: {
+            reference: `Organization/${chance.word({ length: 15 })}`,
+        },
+    };
+};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest --silent --passWithNoTests --testPathPattern=src/*",
-    "int-test": "jest --testPathPattern=integration-test/*",
+    "int-test": "jest --runInBand --testPathPattern=integration-test/*",
     "test-coverage": "jest --coverage",
     "release": "yarn run build && yarn run lint && yarn run test",
     "clean": "rm -rf build/* node_modules/* dist/* .serverless/* .nyc_output/*",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest --silent --passWithNoTests --testPathPattern=src/*",
-    "int-test": "jest --runInBand --testPathPattern=integration-test/*",
+    "int-test": "jest --testPathPattern=integration-test/*",
     "test-coverage": "jest --coverage",
     "release": "yarn run build && yarn run lint && yarn run test",
     "clean": "rm -rf build/* node_modules/* dist/* .serverless/* .nyc_output/*",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "serverless-http": "^2.3.1"
   },
   "devDependencies": {
+    "@types/chance": "^1.1.1",
     "@types/express": "^4.17.2",
     "@types/jest": "^26.0.19",
     "@types/node": "^12",
@@ -49,6 +50,7 @@
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
     "axios": "^0.21.1",
+    "chance": "^1.1.7",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.10.0",
@@ -65,7 +67,8 @@
     "serverless-step-functions": "^2.27.1",
     "sinon": "^9.0.2",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "wait-for-expect": "^3.0.2"
   },
   "resolutions": {
     "dot-prop": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   "dependencies": {
     "aws-sdk": "^2.785.0",
     "axios": "^0.21.1",
-    "fhir-works-on-aws-authz-rbac": "4.0.0",
-    "fhir-works-on-aws-interface": "4.0.0",
+    "fhir-works-on-aws-authz-rbac": "4.1.0",
+    "fhir-works-on-aws-interface": "7.0.0",
     "fhir-works-on-aws-persistence-ddb": "3.0.0",
-    "fhir-works-on-aws-routing": "3.0.0",
-    "fhir-works-on-aws-search-es": "1.1.0",
+    "fhir-works-on-aws-routing": "4.0.0",
+    "fhir-works-on-aws-search-es": "2.0.0",
     "serverless-http": "^2.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-works-on-aws-deployment",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "FHIR Works on AWS deployment",
   "stackname": "fhir-works-on-aws-deployment",
   "main": "src/index.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,7 +36,9 @@ const OAuthUrl =
 
 export const fhirConfig: FhirConfig = {
     configVersion: 1.0,
-    orgName: 'Organization Name',
+    productInfo: {
+        orgName: 'Organization Name',
+    },
     auth: {
         authorization: authService,
         // Used in Capability Statement Generation only

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,7 +23,14 @@ const authService = IS_OFFLINE ? stubs.passThroughAuthz : new RBACHandler(RBACRu
 const dynamoDbDataService = new DynamoDbDataService(DynamoDb);
 const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb);
 const esSearch = new ElasticSearchService(
-    [{ match: { documentStatus: 'AVAILABLE' } }],
+    [
+        {
+            key: 'documentStatus',
+            value: ['AVAILABLE'],
+            comparisonOperator: '==',
+            logicalOperator: 'AND',
+        },
+    ],
     DynamoDbUtil.cleanItem,
     fhirVersion,
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,6 +1258,11 @@
   dependencies:
     chalk "*"
 
+"@types/chance@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/chance/-/chance-1.1.1.tgz#2e06aeaf58130470f2dfe96017cdbc403de002f9"
+  integrity sha512-Ze94JMnM33+dj/tQCWxXWaQ80uYmV9HwydTyrbHAiBa91ETQuI+3iF5OFPicDpQx+md+/6rDpTp9I2VKOGOtpw==
+
 "@types/cls-hooked@*":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/cls-hooked/-/cls-hooked-4.3.1.tgz#0fdfd38f827aa77d15120871e9ca5c593840b2e1"
@@ -2519,6 +2524,11 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chance@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/chance/-/chance-1.1.7.tgz#e99dde5ac16681af787b5ba94c8277c090d6cfe8"
+  integrity sha512-bua/2cZEfzS6qPm0vi3JEvGNbriDLcMj9lKxCQOjUcCJRcyjA7umP0zZm6bKWWlBN04vA0L99QGH/CZQawr0eg==
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -9357,6 +9367,11 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
+
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,6 +3341,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -4165,29 +4170,29 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.0.tgz#3ffb6395453e3f3efff850404f0a59b6747f5f41"
   integrity sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==
 
-fhir-works-on-aws-authz-rbac@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-authz-rbac/-/fhir-works-on-aws-authz-rbac-4.0.0.tgz#75e51afbf38659603e16001e665c762b57d45120"
-  integrity sha512-WD+NGNxProlGT5Y6Djwv8gdW8fhhl/jr0NaJjX5/d0z5EXlJpQpbhhzpz2opECD2bGiiCOozU11IlJq2ZzK7sQ==
+fhir-works-on-aws-authz-rbac@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-authz-rbac/-/fhir-works-on-aws-authz-rbac-4.1.0.tgz#89759df8daab48a1d2fdc2a3b6427dcb587c094f"
+  integrity sha512-1JqiohfFsw7+43hGDXRCSzbW5eLu2LJSGnkI/NlAvIQ0AyoxFDCqH/cFc8SIaNCPW9NJz1x1MFwV/YcRFlvr1A==
   dependencies:
-    fhir-works-on-aws-interface "^4.0.0"
+    fhir-works-on-aws-interface "^6.0.0"
     jsonwebtoken "^8.5.1"
     lodash "^4.17.20"
 
-fhir-works-on-aws-interface@4.0.0, fhir-works-on-aws-interface@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-4.0.0.tgz#4d857dc62a867fba596a02fd481034a94ca93ac0"
-  integrity sha512-7onyEoHuwd+xQoMl6OlugCSahhtrYDNgmy4tYgcsGzTpnbDhQKpDbJUizW1vrpH9t/mPstSYxsBSc1WQ0rl2EA==
-
-fhir-works-on-aws-interface@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-2.0.0.tgz#98c04208c32653f9d75743663c036f1d6eae6ffb"
-  integrity sha512-hdjZJaNEoSYXYVEDOtCQW/HxnQhnF2Nu02nzgeNEWdsZN8MiMakmLX/JxnPYmG13/L9J69CpeV1PmZCsT9HG3g==
+fhir-works-on-aws-interface@7.0.0, fhir-works-on-aws-interface@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-7.0.0.tgz#2cd4ffb20b42dc3d4ec9a98d90437052841ec6d6"
+  integrity sha512-drZNzZ1zdRgGxOQFdGrEAHJwt77MnyrUw6jQCO9yoX7WBhdLOP0+K1E/4GTnn+AulB7/IJa9bPAKHm5PpybB7Q==
 
 fhir-works-on-aws-interface@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-3.0.0.tgz#e4b5762755108169ef4f5b1ec92fafce8ca66da3"
   integrity sha512-SFzwvu91seWKJCj8Qd6g/Y75eKnJ+y5CPY40ykHiylgN1XxbIy/E/zDkoo2tpjdmomVBcyJAN96/LxGXG9NfJw==
+
+fhir-works-on-aws-interface@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-6.0.1.tgz#64fb2d471712b3521ca17aced682c8dcfda798f4"
+  integrity sha512-3d++FyAFdiry7XsIfXp/CGfP2QFfnarDgFVUic9WozQA64bTMASqAGK6jfNXZS6isHyY2sK3mILbM6hsHrMt1A==
 
 fhir-works-on-aws-persistence-ddb@3.0.0:
   version "3.0.0"
@@ -4205,17 +4210,17 @@ fhir-works-on-aws-persistence-ddb@3.0.0:
     promise.allsettled "^1.0.2"
     uuid "^3.4.0"
 
-fhir-works-on-aws-routing@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-routing/-/fhir-works-on-aws-routing-3.0.0.tgz#63fd4409f78511ab2c3c6dacbde8e371082c06b1"
-  integrity sha512-fWO0nX/U+aJr+1BsD5qebYPErKZB2BzwSDhtRUhv9WfNMT3Tn8Fd8Q+c8Lr4bIlUhK75cfbtunyOmmQQXo1pPA==
+fhir-works-on-aws-routing@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-routing/-/fhir-works-on-aws-routing-4.0.0.tgz#0aeeda7dcb2bbfd962527cd3f6df9fa68dd1392a"
+  integrity sha512-sAa1quUJnyFj9tfPgFekx8tjIXbl82bptv/P3cZ4MKLP9k3/1fI+JC0kaN5aMrZ/lyLRs/DcI/dw+/EieJvY0w==
   dependencies:
     "@types/express-serve-static-core" "^4.17.2"
     ajv "^6.11.0"
     cors "^2.8.5"
     errorhandler "^1.5.1"
     express "^4.17.1"
-    fhir-works-on-aws-interface "^4.0.0"
+    fhir-works-on-aws-interface "^7.0.0"
     flat "^5.0.0"
     http-errors "^1.8.0"
     lodash "^4.17.15"
@@ -4223,16 +4228,17 @@ fhir-works-on-aws-routing@3.0.0:
     serverless-http "^2.3.1"
     uuid "^3.4.0"
 
-fhir-works-on-aws-search-es@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-search-es/-/fhir-works-on-aws-search-es-1.1.0.tgz#b0856dc1990ef277a5a8359b25556d6882d9b303"
-  integrity sha512-kvprngWZg85P0vXOlQcakbtigrQEBC3bVPAbEdXVBuKqzMYpXd8ycuuMiDiFi/G9iV20Y5/Pu1cX9KBRHS7SHA==
+fhir-works-on-aws-search-es@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-search-es/-/fhir-works-on-aws-search-es-2.0.0.tgz#721dd1d96d9eb95808448a3b5b9145ba0efce957"
+  integrity sha512-EtbOvsmZTYDTsbxAio6IhuA/+isVW7oeqbDeuw911uuecBkmBd2sm/nlsOaF7HxoMPgWkoB//izycwoGMuFuzg==
   dependencies:
     "@elastic/elasticsearch" "7"
     aws-elasticsearch-connector "^8.2.0"
     aws-sdk "^2.610.0"
-    fhir-works-on-aws-interface "^2.0.0"
+    fhir-works-on-aws-interface "^7.0.0"
     lodash "^4.17.20"
+    nearley "^2.20.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -6706,6 +6712,11 @@ moment@^2.26.0, moment@^2.27.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
   integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
 
+moo@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
+  integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -6785,6 +6796,16 @@ ncjsm@^4.0.1:
     find-requires "^1.0.0"
     fs2 "^0.3.6"
     type "^2.0.0"
+
+nearley@^2.20.0:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -7606,6 +7627,11 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
 ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
@@ -7615,6 +7641,14 @@ ramda@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 range-parser@~1.2.1:
   version "1.2.1"


### PR DESCRIPTION

This PR adds the following features:
- FHIR search parameters can now be used in queries (i.e, the ones at the bottom of https://www.hl7.org/fhir/patient.html). Each FHIR resource type has a different set of search parameters. The complete list of search parameters can be found on the FHIR documentation.
- The capability statement returned from `/metadata` now includes the details of all search parameters supported by FWoA.
- Search requests using invalid search parameters now return an error instead of an empty result set

Most of the changes are found in the interface, search and routing packages. Here we are just bumping package versions and adding integration tests.

**Testing:** 
I deployed these changes and ran all tests successfully on my AWS account.

**Notes:**
- updated bulk export to filter out the `_references` field introduced by https://github.com/awslabs/fhir-works-on-aws-persistence-ddb/pull/44

**Checklist:**

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
