### PR TITLE
chore: Add @types/cors to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "serverless-http": "^2.3.1"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.9",
     "@types/express": "^4.17.2",
     "@types/jest": "^26.0.19",
     "@types/node": "^12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cors@^2.8.9":
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.9.tgz#4bd1fcac72eca8d5bec93e76c7fdcbdc1bc2cd4a"
+  integrity sha512-zurD1ibz21BRlAOIKP8yhrxlqKx6L9VCwkB5kMiP6nZAhoF5MvC7qS1qPA7nRcr1GJolfkQC7/EAL4hdYejLtg==
+
 "@types/express-serve-static-core@*":
   version "4.17.9"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz#2d7b34dcfd25ec663c25c85d76608f8b249667f1"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This resolves a warning when running `sls deploy`
```
/Volumes/unix/workplace/fhir-works-on-aws-deployment/node_modules/fhir-works-on-aws-routing/lib/app.d.ts (2,29): Could not find a declaration file for module 'cors'. '/Volumes/unix/workplace/fhir-works-on-aws-deployment/node_modules/cors/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/cors` if it exists or add a new declaration (.d.ts) file containing `declare module 'cors';`
```

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
