### PR TITLE
chore: Update GH actions to also run build on PR requests instead of just unit test and linting

### DIFF
--- a/.github/workflows/build-and-validate.yaml
+++ b/.github/workflows/build-and-validate.yaml
@@ -3,14 +3,14 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-name: Unit Test
+name: Build and validate
 on:
   pull_request:
     branches:
       - develop
 jobs:
-  unit-test:
-    name: Unit Test and Linting
+  build-validate:
+    name: Build and validate
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -27,15 +27,9 @@ jobs:
           yarn install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Lint
+      - name: Build, lint, and run unit tests
         run: |
           cd auditLogMover
-          yarn lint
+          yarn release
           cd ..
-          yarn lint
-      - name: Unit tests
-        run: |
-          cd auditLogMover
-          yarn test
-          cd ..
-          yarn test
+          yarn release

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,8 +9,8 @@ on:
     branches:
       - develop
 jobs:
-  unit-test:
-    name: Unit Test and Linting
+  build-validate:
+    name: Build and validate
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -27,16 +27,14 @@ jobs:
           yarn install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Lint
+      - name: Build, lint, and run unit tests
         run: |
           cd auditLogMover
-          yarn lint
+          yarn release
           cd ..
-          yarn lint
-      - name: Unit tests
-        run: yarn test
+          yarn release
   pre-deployment-check:
-    needs: unit-test
+    needs: build-validate
     runs-on: ubuntu-18.04
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Description of changes:
Update GH actions to also run build on PR requests instead of just unit test and linting

Checklist:



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
