### PR TITLE
feat: add Implementation Guides compiler script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
     "aws-sdk": "^2.785.0",
     "axios": "^0.21.1",
     "fhir-works-on-aws-authz-rbac": "4.1.1",
-    "fhir-works-on-aws-interface": "7.0.1",
+    "fhir-works-on-aws-interface": "7.1.0",
     "fhir-works-on-aws-persistence-ddb": "3.2.0",
     "fhir-works-on-aws-routing": "4.0.3",
     "fhir-works-on-aws-search-es": "2.0.1",
-    "serverless-http": "^2.3.1"
+    "serverless-http": "^2.3.1",
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "@types/chance": "^1.1.1",
@@ -68,7 +69,8 @@
     "sinon": "^9.0.2",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3",
-    "wait-for-expect": "^3.0.2"
+    "wait-for-expect": "^3.0.2",
+    "tmp-promise": "^3.0.2"
   },
   "resolutions": {
     "dot-prop": "^5.1.1",

--- a/scripts/compile-igs.ts
+++ b/scripts/compile-igs.ts
@@ -1,6 +1,7 @@
-import { join } from 'path';
+import { join, dirname } from 'path';
 import yargs from 'yargs';
 import { SearchImplementationGuides } from 'fhir-works-on-aws-search-es';
+import { existsSync, mkdirSync } from 'fs';
 import { IGCompiler } from '../src/IGCompiler';
 
 const PROJECT_DIR = join(__dirname, '..');
@@ -29,6 +30,16 @@ async function compileIGs() {
     const options = {
         ignoreVersion: cmdArgs.ignoreVersion,
     };
+    if (!existsSync(cmdArgs.igPath)) {
+        console.log(`IGs folder '${cmdArgs.igPath}' does not exist. No IGs found, exiting...`);
+        return;
+    }
+    const compiledIgsDir = dirname(cmdArgs.outputFile);
+    if (!existsSync(compiledIgsDir)) {
+        console.log(`folder for compiled IGs '${compiledIgsDir}' does not exist, creating it`);
+        mkdirSync(compiledIgsDir, { recursive: true });
+    }
+
     try {
         await new IGCompiler(SearchImplementationGuides, options).compileIGs(cmdArgs.igPath, cmdArgs.outputFile);
     } catch (ex) {

--- a/scripts/compile-igs.ts
+++ b/scripts/compile-igs.ts
@@ -1,0 +1,39 @@
+import { join } from 'path';
+import yargs from 'yargs';
+import { SearchImplementationGuides } from 'fhir-works-on-aws-search-es';
+import { IGCompiler } from '../src/IGCompiler';
+
+const PROJECT_DIR = join(__dirname, '..');
+
+function parseCmdOptions() {
+    return yargs(process.argv.slice(2))
+        .usage('Usage: $0 [--ignoreVersion, -i ] [--igPath, -p IG pack directory] [--outputFile, -o output ]')
+        .describe('ignoreVersion', "Don't care whether version of dependency lines up with version of installed IG")
+        .boolean('ignoreVersion')
+        .default('ignoreVersion', false)
+        .alias('i', 'ignoreVersion')
+        .describe('igPath', 'Path to folder with IG pack sub folders')
+        .default('igPath', join(PROJECT_DIR, 'implementationGuides/'))
+        .alias('p', 'igPath')
+        .describe('outputFile', 'Path to compiled output JSON file')
+        .alias('o', 'outputFile')
+        .default('outputFile', join(PROJECT_DIR, 'compiledImplementationGuides/fhir-works-on-aws-search-es.json')).argv;
+}
+
+/**
+ * main function of the script
+ * parse command line arguments and invoke compiler
+ * */
+async function compileIGs() {
+    const cmdArgs = parseCmdOptions();
+    const options = {
+        ignoreVersion: cmdArgs.ignoreVersion,
+    };
+    try {
+        await new IGCompiler(SearchImplementationGuides, options).compileIGs(cmdArgs.igPath, cmdArgs.outputFile);
+    } catch (ex) {
+        console.error('Exception: ', ex.message, ex.stack);
+    }
+}
+
+compileIGs();

--- a/src/IGCompiler.test.ts
+++ b/src/IGCompiler.test.ts
@@ -1,0 +1,179 @@
+/* eslint no-restricted-syntax: 0 */
+/* eslint no-await-in-loop: 0 */
+/* eslint class-methods-use-this: 0 */
+
+import { dir, DirectoryResult } from 'tmp-promise';
+import { join } from 'path';
+import { existsSync, mkdirSync, PathLike } from 'fs';
+import { ImplementationGuides } from 'fhir-works-on-aws-interface';
+import { IGCompiler, IGCompilerOptions, loadJson, storeJson } from './IGCompiler';
+
+class MockImplementationGuides implements ImplementationGuides {
+    compile(input: any[]): Promise<any> {
+        return Promise.resolve({
+            input,
+        });
+    }
+}
+
+interface IGVersion {
+    version: string;
+    deps: string[];
+}
+
+describe('IGCompiler tests', function() {
+    let workDir: DirectoryResult;
+    let igsDir: PathLike;
+    let output: string;
+
+    async function createIGs(options: IGCompilerOptions, igs: { [key: string]: IGVersion }) {
+        for (const [igName, igInfo] of Object.entries(igs)) {
+            const igPath = join(igsDir.toString(), igName);
+            mkdirSync(igPath);
+            await storeJson(join(igPath, 'searchParam1.json'), { igName, name: 'param1' });
+            await storeJson(join(igPath, 'searchParam2.json'), { igName, name: 'param2' });
+            const indexJson = {
+                files: [
+                    {
+                        resourceType: 'SearchParameter',
+                        filename: 'searchParam1.json',
+                    },
+                    {
+                        resourceType: 'SearchParameter',
+                        filename: 'searchParam2.json',
+                    },
+                    {
+                        resourceType: 'ValueSet',
+                        filename: 'searchParam1.json',
+                    },
+                ],
+            };
+            await storeJson(join(igPath, '.index.json'), indexJson);
+            const dependencies: { [key: string]: string } = {};
+            igInfo.deps.forEach((value: string) => {
+                const { version } = igs[value];
+                dependencies[value] = version;
+            });
+            await storeJson(join(igPath, 'package.json'), {
+                name: igName,
+                version: igInfo.version,
+                url: `http://http://hl7.org/fhir/${igName}`,
+                dependencies,
+            });
+        }
+        const implementationGuides = new MockImplementationGuides();
+        const igCompiler = new IGCompiler(implementationGuides, options);
+        console.log('Done creating IGs');
+        return igCompiler;
+    }
+
+    beforeEach(async function() {
+        workDir = await dir({ unsafeCleanup: true });
+        igsDir = join(workDir.path, 'igs');
+        mkdirSync(igsDir);
+        output = join(workDir.path, 'output.json');
+        console.log('before each');
+    });
+
+    afterEach(async function() {
+        console.log('cleaning up');
+        await workDir.cleanup();
+    });
+
+    it('compile a few IGs', async function() {
+        const options: IGCompilerOptions = {
+            ignoreVersion: true,
+        };
+        const igCompiler = await createIGs(options, {
+            'hl7.fhir.r4.core': {
+                version: '4.0.1',
+                deps: [],
+            },
+            'hl7.fhir.us.carin-bb': {
+                version: '1.0.0',
+                deps: ['hl7.fhir.r4.core', 'hl7.fhir.us.core'],
+            },
+            'hl7.fhir.us.core': {
+                version: '3.1.0',
+                deps: ['hl7.fhir.r4.core'],
+            },
+            'hl7.fhir.us.davinci-pdex-plan-net': {
+                version: '1.0.0',
+                deps: ['hl7.fhir.us.carin-bb'],
+            },
+            'us.nlm.vsac': {
+                version: '0.3.0',
+                deps: ['hl7.fhir.us.core'],
+            },
+        });
+        await igCompiler.compileIGs(igsDir, output);
+        expect(existsSync(output)).toEqual(true);
+        expect(await loadJson(output)).toEqual({
+            input: [
+                {
+                    igName: 'hl7.fhir.us.carin-bb',
+                    name: 'param1',
+                },
+                {
+                    igName: 'hl7.fhir.us.carin-bb',
+                    name: 'param2',
+                },
+                {
+                    igName: 'hl7.fhir.us.core',
+                    name: 'param1',
+                },
+                {
+                    igName: 'hl7.fhir.us.core',
+                    name: 'param2',
+                },
+                {
+                    igName: 'hl7.fhir.us.davinci-pdex-plan-net',
+                    name: 'param1',
+                },
+                {
+                    igName: 'hl7.fhir.us.davinci-pdex-plan-net',
+                    name: 'param2',
+                },
+                {
+                    igName: 'us.nlm.vsac',
+                    name: 'param1',
+                },
+                {
+                    igName: 'us.nlm.vsac',
+                    name: 'param2',
+                },
+            ],
+        });
+    });
+
+    it('circular dependencies', async function() {
+        const options: IGCompilerOptions = {
+            ignoreVersion: false,
+        };
+        const igCompiler = await createIGs(options, {
+            'hl7.fhir.r4.core': {
+                version: '4.0.1',
+                deps: [],
+            },
+            'hl7.fhir.us.carin-bb': {
+                version: '1.0.0',
+                deps: ['hl7.fhir.r4.core', 'hl7.fhir.us.core'],
+            },
+            'hl7.fhir.us.core': {
+                version: '3.1.0',
+                deps: ['hl7.fhir.r4.core', 'us.nlm.vsac'],
+            },
+            'hl7.fhir.us.davinci-pdex-plan-net': {
+                version: '1.0.0',
+                deps: ['hl7.fhir.us.carin-bb'],
+            },
+            'us.nlm.vsac': {
+                version: '0.3.0',
+                deps: ['hl7.fhir.us.core', 'hl7.fhir.us.davinci-pdex-plan-net'],
+            },
+        });
+        await expect(igCompiler.compileIGs(igsDir, output)).rejects.toThrow(
+            'Circular dependency found: hl7.fhir.us.carin-bb@1.0.0 -> hl7.fhir.us.core@3.1.0 -> us.nlm.vsac@0.3.0 -> hl7.fhir.us.core@3.1.0',
+        );
+    });
+});

--- a/src/IGCompiler.ts
+++ b/src/IGCompiler.ts
@@ -1,0 +1,168 @@
+import { existsSync, PathLike, readdir, readFile, writeFile, realpathSync, statSync } from 'fs';
+import util from 'util';
+import path from 'path';
+import { ImplementationGuides } from 'fhir-works-on-aws-interface';
+
+/* eslint no-restricted-syntax: 0 */
+/* eslint no-await-in-loop: 0 */
+/* eslint class-methods-use-this: 0 */
+
+const readFilePmd = util.promisify(readFile);
+const readDirPmd = util.promisify(readdir);
+const writeFilePmd = util.promisify(writeFile);
+
+const BASE_FHIR_NAME = 'hl7.fhir.r4.core';
+
+export async function loadJson(fileName: PathLike): Promise<any> {
+    return JSON.parse(await readFilePmd(fileName, 'utf8'));
+}
+
+export async function storeJson(fileName: PathLike, data: any) {
+    await writeFilePmd(fileName, JSON.stringify(data));
+}
+
+async function listIgDirs(parentDir: PathLike): Promise<string[]> {
+    return (await readDirPmd(parentDir, { withFileTypes: true }))
+        .filter(dirent => {
+            return (
+                dirent.isDirectory() ||
+                (dirent.isSymbolicLink() &&
+                    statSync(realpathSync(path.join(parentDir.toString(), dirent.name))).isDirectory())
+            );
+        })
+        .map(dirent => {
+            return path.join(parentDir.toString(), dirent.name);
+        });
+}
+
+export interface IGCompilerOptions {
+    ignoreVersion: boolean;
+}
+
+export interface IGInfo {
+    id: string;
+    name: string;
+    version: string;
+    url: string;
+    path: string;
+    dependencies: string[];
+}
+
+/**
+ *  Helper class used for compiling IGs. Its main functions are:
+ *  - Looks through a folder of IG packs
+ *  - Make sure no dependencies are missing
+ *  - and there are no circular dependencies
+ *  - calls compile function for each SearchParameters
+ *
+ */
+export class IGCompiler {
+    private options: IGCompilerOptions;
+
+    private readonly implementationGuides: ImplementationGuides;
+
+    constructor(implementationGuides: ImplementationGuides, options: IGCompilerOptions) {
+        this.options = options;
+        this.implementationGuides = implementationGuides;
+    }
+
+    async collectResources(igDir: PathLike, resources: any[]): Promise<void> {
+        const indexJson = path.join(igDir.toString(), '.index.json');
+        if (!existsSync(indexJson)) {
+            return;
+        }
+        const index: any = await loadJson(indexJson);
+        for (const file of index.files) {
+            if (file.resourceType === 'SearchParameter') {
+                const filePath = path.join(igDir.toString(), file.filename);
+                console.log(`Compiling ${filePath}`);
+                resources.push(await loadJson(filePath));
+            }
+        }
+    }
+
+    /**
+     * Main public function
+     * @param igsDir
+     * @param outputPath
+     */
+    public async compileIGs(igsDir: PathLike, outputPath: PathLike): Promise<void> {
+        const resources: any[] = [];
+        if (!existsSync(igsDir)) {
+            throw new Error(`'${igsDir}' doesn't exist`);
+        }
+        for (const igInfo of await this.collectIGInfos(igsDir)) {
+            await this.collectResources(igInfo.path, resources);
+        }
+        const compiledResources = await this.implementationGuides.compile(resources);
+        await storeJson(outputPath, compiledResources);
+    }
+
+    createIGKey(name: string, version: string) {
+        if (this.options.ignoreVersion) {
+            return name;
+        }
+        return `${name}@${version}`;
+    }
+
+    async extractIgInfo(igDir: PathLike): Promise<IGInfo | null> {
+        const packagePath = path.join(igDir.toString(), 'package.json');
+        if (!existsSync(packagePath)) {
+            return null;
+        }
+        console.log(`checking ${packagePath}`);
+        const packageJson: any = await loadJson(packagePath);
+        const dependencies: string[] = [];
+        const igInfo = {
+            id: this.createIGKey(packageJson.name, packageJson.version),
+            url: packageJson.url,
+            name: packageJson.name,
+            version: packageJson.version,
+            path: igDir.toString(),
+            dependencies,
+        };
+        const packageDeps: { [key: string]: string } = packageJson.dependencies;
+        if (packageDeps) {
+            for (const [name, version] of Object.entries(packageDeps)) {
+                const igId: string = this.createIGKey(name, version);
+                dependencies.push(igId);
+            }
+        }
+        return igInfo;
+    }
+
+    async collectIGInfos(igsDir: PathLike): Promise<IGInfo[]> {
+        const igInfos: IGInfo[] = [];
+        const parentMap: { [key: string]: string[] } = {};
+        for (const igPath of await listIgDirs(igsDir)) {
+            console.log(`looking at ig path: ${igPath}`);
+            const igInfo = await this.extractIgInfo(igPath);
+            if (igInfo) {
+                if (igInfo.name !== BASE_FHIR_NAME) {
+                    igInfos.push(igInfo);
+                }
+                parentMap[igInfo.id] = igInfo.dependencies;
+            }
+        }
+        for (const igId of Object.keys(parentMap)) {
+            this.depthFirst([igId], parentMap);
+        }
+        return igInfos;
+    }
+
+    depthFirst(parents: string[], pMap: { [key: string]: string[] }): void {
+        const igId = parents[parents.length - 1];
+        const dependencies = pMap[igId];
+        if (!dependencies) {
+            throw new Error(`Missing dependency ${igId}`);
+        }
+        for (const parentId of dependencies) {
+            if (parents.includes(parentId)) {
+                throw new Error(`Circular dependency found: ${parents.join(' -> ')} -> ${parentId}`);
+            }
+            parents.push(parentId);
+            this.depthFirst(parents, pMap);
+            parents.pop();
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2462,6 +2462,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone-response@1.0.2, clone-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
@@ -3346,6 +3355,11 @@ es6-weak-map@^2.0.3:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -3405,7 +3419,7 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import@^2.20.0:
+eslint-plugin-import@^2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
   integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
@@ -3866,7 +3880,12 @@ fhir-works-on-aws-authz-rbac@4.1.1:
     jsonwebtoken "^8.5.1"
     lodash "^4.17.20"
 
-fhir-works-on-aws-interface@7.0.1, fhir-works-on-aws-interface@^7.0.0, fhir-works-on-aws-interface@^7.0.1:
+fhir-works-on-aws-interface@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-7.1.0.tgz#74ec69861b9909b9d14925085a901162def8ad6c"
+  integrity sha512-0Tz0ZXycp3vnKSyjnPO94rKJ7Qtz4JWLy83HpB1+qdGaAxzGaMVyW7w3vC3fkPmqOIPKxVl96pU/tXS7/Q9J8g==
+
+fhir-works-on-aws-interface@^7.0.0, fhir-works-on-aws-interface@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-7.0.1.tgz#f5fd41ae218d77c6bdc54452c3102a4990c5e4bc"
   integrity sha512-Ax3yBruz5eeVaBxtEuLQQYdqEIDfqK6nfAT2iWUG7Ky9Warja/3Y4tAIYdiBhYaQ4anFQgz9nyYFQTQUH0JyLQ==
@@ -4196,7 +4215,7 @@ gensync@^1.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -8368,12 +8387,26 @@ timers-ext@^0.1.7:
     es5-ext "~0.10.46"
     next-tick "1"
 
+tmp-promise@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"
+  integrity sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -8920,6 +8953,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -9006,6 +9048,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -9029,7 +9076,7 @@ yamljs@^0.3.0:
     argparse "^1.0.7"
     glob "^7.0.5"
 
-yargs-parser@20.x:
+yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
@@ -9058,6 +9105,19 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yauzl@^2.4.2:
   version "2.10.0"


### PR DESCRIPTION
Issue #, if available: INT-931

Description of changes:
Added a IGCompiler TypeScript class to src and a compile-igs.ts script to the scripts folder.  
Its purpose of the class is 
 * to search through a directory and find any sub directory containing an IG package.
 * collect high level name and version info for each IG package
 * make sure there aren't any missing dependencies 
 * make sure there are no circular dependencies
 * extract all the SearchParameters (needs to be parameterized in the future)
 * pass list of SearchParameter instances to SearchImplementationGuides.compile function
 * store output in a JSON file

The compile-igs.ts script does
 * parse command line arguments
 * import ImplementationGuides implementation (implementations in the future
 * invoke IGCompiler
 * catch and report errors

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
