### PR TITLE
chore: Add Inferno Tests to GH Actions for "SMART" branch

### DIFF
--- a/.github/workflows/build-and-validate.yaml
+++ b/.github/workflows/build-and-validate.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - develop
+      - smart-develop
       - authz-smart
 jobs:
   build-validate:

--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -1,0 +1,119 @@
+name: (SMART) Unit Tests, Deploy, Integration Test
+on:
+  push:
+    branches:
+      - smart-develop
+jobs:
+  build-validate:
+    name: Build and validate
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: |
+          cd auditLogMover
+          yarn install
+          cd ..
+          yarn install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Build, lint, and run unit tests
+        run: |
+          cd auditLogMover
+          yarn release
+          cd ..
+          yarn release
+  pre-deployment-check:
+    needs: build-validate
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    steps:
+      - name: 'Block Concurrent Deployments'
+        uses: softprops/turnstyle@v1
+        with:
+          poll-interval-seconds: 10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  deploy:
+    needs: pre-deployment-check
+    name: Deploy to Dev
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install serverless
+        run: npm install -g serverless
+      - name: Deploy FHIR Server and ddbToEs
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          yarn install
+          serverless deploy --stage dev --region us-east-1 --conceal
+      - name: Deploy auditLogMover
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          cd auditLogMover
+          yarn install
+          serverless deploy --stage dev --region us-east-1 --conceal
+  inferno-test:
+#    needs: deploy
+    name: Run Inferno Tests
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: nguyen102/inferno
+          ref: fhir-works
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - name: Install dependency
+        run: |
+          gem install bundler
+          bundle install
+      - name: Execute tests
+        env:
+          SERVICE_URL: ${{ secrets.SMART_SERVICE_URL}}
+          CLIENT_ID: ${{ secrets.SMART_AUTH_CLIENT_ID}}
+          CLIENT_SECRET: ${{ secrets.SMART_AUTH_CLIENT_SECRET }}
+          AUTH_ENDPOINT: ${{ secrets.SMART_AUTH_ENDPOINT }}
+          TOKEN_ENDPOINT: ${{ secrets.SMART_TOKEN_ENDPOINT}}
+          AUTH_USERNAME: ${{ secrets.SMART_AUTH_USERNAME}}
+          AUTH_PASSWORD: ${{ secrets.SMART_AUTH_PASSWORD}}
+        run: |
+          cp fhir-works-example.json fhir-works.json
+          sed -i -e "s#SERVER_ENDPOINT#$SERVICE_URL#g" fhir-works.json
+          sed -i -e "s#CLIENT_ID#$CLIENT_ID#g" fhir-works.json
+          sed -i -e "s#CLIENT_SECRET#$CLIENT_SECRET#g" fhir-works.json
+          sed -i -e "s#AUTH_ENDPOINT#$AUTH_ENDPOINT#g" fhir-works.json
+          sed -i -e "s#TOKEN_ENDPOINT#$TOKEN_ENDPOINT#g" fhir-works.json
+          sed -i -e "s#AUTH_USERNAME#$AUTH_USERNAME#g" fhir-works.json
+          sed -i -e "s/AUTH_PASSWORD/$AUTH_PASSWORD/g" fhir-works.json
+          bundle exec rake db:create db:schema:load
+          bundle exec rake inferno:execute_batch[fhir-works.json]
+  merge-develop-to-smart-mainline:
+    needs: inferno-test
+    name: Merge develop to mainline
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Merge to smart-mainline branch
+        uses: devmasx/merge-branch@v1.1.0
+        with:
+          type: now
+          target_branch: 'smart-mainline'
+        env:
+          GITHUB_TOKEN: ${{secrets.MERGE_TOKEN}}

--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -20,8 +20,6 @@ jobs:
           yarn install
           cd ..
           yarn install
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build, lint, and run unit tests
         run: |
           cd auditLogMover
@@ -54,22 +52,21 @@ jobs:
         run: npm install -g serverless
       - name: Deploy FHIR Server and ddbToEs
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.SMART_AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SMART_AWS_SECRET_ACCESS_KEY }}
         run: |
           yarn install
-          serverless deploy --stage dev --region us-east-1 --conceal
+          serverless deploy --stage dev --region us-east-2 --conceal
       - name: Deploy auditLogMover
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.SMART_AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SMART_AWS_SECRET_ACCESS_KEY }}
         run: |
           cd auditLogMover
           yarn install
-          serverless deploy --stage dev --region us-east-1 --conceal
+          serverless deploy --stage dev --region us-east-2 --conceal
   inferno-test:
-#    needs: deploy
+    needs: deploy
     name: Run Inferno Tests
     runs-on: ubuntu-18.04
     steps:
@@ -101,7 +98,7 @@ jobs:
           sed -i -e "s#AUTH_ENDPOINT#$AUTH_ENDPOINT#g" fhir-works.json
           sed -i -e "s#TOKEN_ENDPOINT#$TOKEN_ENDPOINT#g" fhir-works.json
           sed -i -e "s#AUTH_USERNAME#$AUTH_USERNAME#g" fhir-works.json
-          sed -i -e "s/AUTH_PASSWORD/$AUTH_PASSWORD/g" fhir-works.json
+          sed -i -e "s#AUTH_PASSWORD#$AUTH_PASSWORD#g" fhir-works.json
           bundle exec rake db:create db:schema:load
           bundle exec rake inferno:execute_batch[fhir-works.json]
   merge-develop-to-smart-mainline:

--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -1,0 +1,42 @@
+name: (SMART) Unit Tests, Deploy, Integration Test
+on:
+  push:
+    branches:
+      -  smart-develop
+jobs:
+  inferno-test:
+#    needs: deploy
+    name: Run Inferno Tests
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: nguyen102/inferno
+          ref: fhir-works
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - name: Install dependency
+        run: |
+          gem install bundler
+          bundle install
+      - name: Execute tests
+        env:
+          SERVICE_URL: ${{ secrets.SMART_SERVICE_URL}}
+          CLIENT_ID: ${{ secrets.SMART_AUTH_CLIENT_ID}}
+          CLIENT_SECRET: ${{ secrets.SMART_AUTH_CLIENT_SECRET }}
+          AUTH_ENDPOINT: ${{ secrets.SMART_AUTH_ENDPOINT }}
+          TOKEN_ENDPOINT: ${{ secrets.SMART_TOKEN_ENDPOINT}}
+          AUTH_USERNAME: ${{ secrets.SMART_AUTH_USERNAME}}
+          AUTH_PASSWORD: ${{ secrets.SMART_AUTH_PASSWORD}}
+        run: |
+          cp fhir-works-example.json fhir-works.json
+          sed -i -e "s#SERVER_ENDPOINT#$SERVICE_URL#g" fhir-works.json
+          sed -i -e "s#CLIENT_ID#$CLIENT_ID#g" fhir-works.json
+          sed -i -e "s#CLIENT_SECRET#$CLIENT_SECRET#g" fhir-works.json
+          sed -i -e "s#AUTH_ENDPOINT#$AUTH_ENDPOINT#g" fhir-works.json
+          sed -i -e "s#TOKEN_ENDPOINT#$TOKEN_ENDPOINT#g" fhir-works.json
+          sed -i -e "s#AUTH_USERNAME#$AUTH_USERNAME#g" fhir-works.json
+          sed -i -e "s/AUTH_PASSWORD/$AUTH_PASSWORD/g" fhir-works.json
+          bundle exec rake db:create db:schema:load
+          bundle exec rake inferno:execute_batch[fhir-works.json]

--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -2,7 +2,7 @@ name: (SMART) Unit Tests, Deploy, Integration Test
 on:
   push:
     branches:
-      -  smart-develop
+      - smart-develop
 jobs:
   build-validate:
     name: Build and validate
@@ -50,10 +50,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: Setup config file
-        env:
-          DEV_AWS_USER_ACCOUNT_ARN: ${{ secrets.DEV_AWS_USER_ACCOUNT_ARN }}
-        run: sed "s#<dev-arn>#$DEV_AWS_USER_ACCOUNT_ARN#g" serverless_config.template.json > serverless_config.json
       - name: Install serverless
         run: npm install -g serverless
       - name: Deploy FHIR Server and ddbToEs
@@ -114,7 +110,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Merge to mainline branch
+      - name: Merge to smart-mainline branch
         uses: devmasx/merge-branch@v1.1.0
         with:
           type: now

--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -4,6 +4,74 @@ on:
     branches:
       -  smart-develop
 jobs:
+  build-validate:
+    name: Build and validate
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: |
+          cd auditLogMover
+          yarn install
+          cd ..
+          yarn install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Build, lint, and run unit tests
+        run: |
+          cd auditLogMover
+          yarn release
+          cd ..
+          yarn release
+  pre-deployment-check:
+    needs: build-validate
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    steps:
+      - name: 'Block Concurrent Deployments'
+        uses: softprops/turnstyle@v1
+        with:
+          poll-interval-seconds: 10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  deploy:
+    needs: pre-deployment-check
+    name: Deploy to Dev
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Setup config file
+        env:
+          DEV_AWS_USER_ACCOUNT_ARN: ${{ secrets.DEV_AWS_USER_ACCOUNT_ARN }}
+        run: sed "s#<dev-arn>#$DEV_AWS_USER_ACCOUNT_ARN#g" serverless_config.template.json > serverless_config.json
+      - name: Install serverless
+        run: npm install -g serverless
+      - name: Deploy FHIR Server and ddbToEs
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          yarn install
+          serverless deploy --stage dev --region us-east-1 --conceal
+      - name: Deploy auditLogMover
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          cd auditLogMover
+          yarn install
+          serverless deploy --stage dev --region us-east-1 --conceal
   inferno-test:
 #    needs: deploy
     name: Run Inferno Tests
@@ -40,3 +108,16 @@ jobs:
           sed -i -e "s/AUTH_PASSWORD/$AUTH_PASSWORD/g" fhir-works.json
           bundle exec rake db:create db:schema:load
           bundle exec rake inferno:execute_batch[fhir-works.json]
+  merge-develop-to-smart-mainline:
+    needs: inferno-test
+    name: Merge develop to mainline
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Merge to mainline branch
+        uses: devmasx/merge-branch@v1.1.0
+        with:
+          type: now
+          target_branch: 'smart-mainline'
+        env:
+          GITHUB_TOKEN: ${{secrets.MERGE_TOKEN}}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,3 +50,37 @@ The deploy script will push all of your packages, except for the `deployment` pa
 
 Run this command to deploy your code to AWS:
 `serverless deploy --aws-profile <PROFILE> --stage <STAGE>`
+
+## Troubleshooting
+
+#### Runtime.ImportModuleError on other FWoA package
+
+If you run into error type `Runtime.ImportModuleError` with error message stating the offending method comes from another FWoA package, check the versions of local FWoA packages match the versions specified in `package.json`. If you see a mismatch, update the version number in `package.json` to match your local packages and commit the change should fix the issue. 
+
+As an example, if your local packages have versions specified as: 
+
+```
+fhir-works-on-aws-authz-rbac@4.1.0+97caac97
+fhir-works-on-aws-persistence-ddb@3.0.0+7f1d59ed
+fhir-works-on-aws-routing@4.0.0+60259b47
+fhir-works-on-aws-search-es@2.0.0+75ad6c2c
+fhir-works-on-aws-interface@7.0.0+ceec8029
+``` 
+
+Then `package.json` should have the same versions specified as well: 
+
+```
+"dependencies": {
+    "aws-sdk": "^2.785.0",
+    "axios": "^0.21.1",
+    "fhir-works-on-aws-authz-rbac": "4.1.0",
+    "fhir-works-on-aws-interface": "7.0.0",
+    "fhir-works-on-aws-persistence-ddb": "3.0.0",
+    "fhir-works-on-aws-routing": "4.0.0",
+    "fhir-works-on-aws-search-es": "2.0.0",
+    "serverless-http": "^2.3.1"
+  },
+```
+
+If you have a mismatch in `package.json`, say `fhir-works-on-aws-routing` was set to `4.1.0` instead of `4.0.0`. An error message 
+

--- a/auditLogMover/package.json
+++ b/auditLogMover/package.json
@@ -12,7 +12,7 @@
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.10.0",
-    "eslint-plugin-import": "^2.20.0",
+    "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.1.2",
     "jest": "^26.6.3",
     "serverless": "^1.72.0",

--- a/auditLogMover/yarn.lock
+++ b/auditLogMover/yarn.lock
@@ -2981,7 +2981,7 @@ eslint-config-prettier@^6.10.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-import-resolver-node@^0.3.3:
+eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
   integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
@@ -2997,17 +2997,17 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import@^2.20.0:
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.21.2.tgz#8fef77475cc5510801bedc95f84b932f7f334a7c"
-  integrity sha512-FEmxeGI6yaz+SnEB6YgNHlQK1Bs2DKLM+YF+vuTk5H8J9CLbJLtlPvRFgZZ2+sXiKAlN5dpdlrWOjK8ZoZJpQA==
+eslint-plugin-import@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
+  integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
   dependencies:
     array-includes "^3.1.1"
     array.prototype.flat "^1.2.3"
     contains-path "^0.1.0"
     debug "^2.6.9"
     doctrine "1.5.0"
-    eslint-import-resolver-node "^0.3.3"
+    eslint-import-resolver-node "^0.3.4"
     eslint-module-utils "^2.6.0"
     has "^1.0.3"
     minimatch "^3.0.4"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.10.0",
-    "eslint-plugin-import": "^2.20.0",
+    "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.1.2",
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -16,9 +16,9 @@ custom:
   exportRequestTableJobStatusIndex: 'jobStatus-index'
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
-  issuerEndpoint: ${opt:issuerEndpoint, 'https://dev-6460611.okta.com/oauth2/default'}
-  oAuth2ApiEndpoint: ${opt:oAuth2ApiEndpoint, 'https://dev-6460611.okta.com/oauth2/default/v1'}
-  patientPickerEndpoint: ${opt:patientPickerEndpoint, 'https://ndh171uu63.execute-api.us-east-1.amazonaws.com/sandbox'}
+  issuerEndpoint: ${opt:issuerEndpoint, 'https://dev-80793861.okta.com/oauth2/default'}
+  oAuth2ApiEndpoint: ${opt:oAuth2ApiEndpoint, 'https://dev-80793861.okta.com/oauth2/default/v1'}
+  patientPickerEndpoint: ${opt:patientPickerEndpoint, 'https://ifhprna212.execute-api.us-east-2.amazonaws.com/sandbox'}
   config: ${file(serverless_config.json)}
 
 provider:

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -19,7 +19,6 @@ custom:
   issuerEndpoint: ${opt:issuerEndpoint, 'https://dev-80793861.okta.com/oauth2/default'}
   oAuth2ApiEndpoint: ${opt:oAuth2ApiEndpoint, 'https://dev-80793861.okta.com/oauth2/default/v1'}
   patientPickerEndpoint: ${opt:patientPickerEndpoint, 'https://ifhprna212.execute-api.us-east-2.amazonaws.com/sandbox'}
-  config: ${file(serverless_config.json)}
 
 provider:
   name: aws


### PR DESCRIPTION
Issue #, if available:

Description of changes:
FHIR-481

On merge to `smart-develop`:
* Run `yarn release`
* Deploy code to SMART test environment. Currently the SMART FHIR resource server is hosted in `fhir.server.smart` account in `us-east-2`, but will be moved to `us-west-2` to be consistent with the regular test environment for `develop` branch. The server will be moved after pen testing is complete.
* Run SMART inferno tests. Repository with example JSON is [here](https://github.com/nguyen102/inferno/blob/fhir-works/fhir-works-example.json)
   * We're running three SMART tests: SMARTDiscoverySequence, ManualRegistrationSequence, StandaloneLaunchSequence

On PR to `smart-develop`:
* Run `yarn release`

**GH Secrets that needs to be Set up**
 ```
    SMART_SERVICE_URL
    SMART_AUTH_CLIENT_ID
    SMART_AUTH_CLIENT_SECRET
    SMART_AUTH_ENDPOINT
    SMART_TOKEN_ENDPOINT
    SMART_AUTH_USERNAME
    SMART_AUTH_PASSWORD

    SMART_AWS_ACCESS_KEY_ID
    SMART_AWS_SECRET_ACCESS_KEY
```
**Tests**
Ran GH Action locally and deployment and tests worked as expected

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
