### PR TITLE
feat: add Implementation Guides integ tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,8 @@ module.exports = {
         'no-empty-function': 'off',
         '@typescript-eslint/no-empty-function': 'error',
         'import/no-extraneous-dependencies': ['error', {'devDependencies': ['**/*.test.ts', 'integration-tests/*']}],
+        'no-shadow': 'off', // replaced by ts-eslint rule below
+        '@typescript-eslint/no-shadow': 'error'
     },
     settings: {
         'import/resolver': {

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -59,6 +59,12 @@ jobs:
         env:
           DEV_AWS_USER_ACCOUNT_ARN: ${{ secrets.DEV_AWS_USER_ACCOUNT_ARN }}
         run: sed "s#<dev-arn>#$DEV_AWS_USER_ACCOUNT_ARN#g" serverless_config.template.json > serverless_config.json
+      - name: Download US Core IG
+        run: |
+          mkdir -p implementationGuides
+          curl https://www.hl7.org/fhir/us/core/package.tgz | tar xz -C implementationGuides
+      - name: Compile IGs
+        run: yarn run compile-igs
       - name: Install serverless
         run: npm install -g serverless
       - name: Deploy FHIR Server and ddbToEs

--- a/integration-tests/implementationGuides.test.ts
+++ b/integration-tests/implementationGuides.test.ts
@@ -19,9 +19,11 @@ describe('Implementation Guides - US Core', () => {
         const capabilityStatement: CapabilityStatement = (await client.get('metadata')).data;
 
         const usCorePatientSearchParams = capabilityStatement.rest[0].resource
-            .filter(x => x.type === 'Patient')
-            .flatMap(x => x.searchParam ?? [])
-            .filter(x => x.definition.startsWith('http://hl7.org/fhir/us/core/SearchParameter/us-core'));
+            .filter(resource => resource.type === 'Patient')
+            .flatMap(resource => resource.searchParam ?? [])
+            .filter(searchParam =>
+                searchParam.definition.startsWith('http://hl7.org/fhir/us/core/SearchParameter/us-core'),
+            );
 
         expect(usCorePatientSearchParams).toEqual(
             // There are many more search parameters in US Core but they are all loaded into FWoA in the same way.
@@ -58,8 +60,6 @@ describe('Implementation Guides - US Core', () => {
                 },
             ]),
         );
-
-        // console.log(usCorePatientSearchParams);
     });
 
     test('query using search parameters', async () => {

--- a/integration-tests/implementationGuides.test.ts
+++ b/integration-tests/implementationGuides.test.ts
@@ -1,0 +1,136 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import { AxiosInstance } from 'axios';
+import waitForExpect from 'wait-for-expect';
+import { Chance } from 'chance';
+import { expectResourceToBePartOfSearchResults, getFhirClient, randomPatient } from './utils';
+import { CapabilityStatement } from './types';
+
+jest.setTimeout(60 * 1000);
+
+describe('Implementation Guides - US Core', () => {
+    let client: AxiosInstance;
+    beforeAll(async () => {
+        client = await getFhirClient();
+    });
+    test('capability statement includes search parameters', async () => {
+        const capabilityStatement: CapabilityStatement = (await client.get('metadata')).data;
+
+        const usCorePatientSearchParams = capabilityStatement.rest[0].resource
+            .filter(x => x.type === 'Patient')
+            .flatMap(x => x.searchParam ?? [])
+            .filter(x => x.definition.startsWith('http://hl7.org/fhir/us/core/SearchParameter/us-core'));
+
+        expect(usCorePatientSearchParams).toEqual(
+            // There are many more search parameters in US Core but they are all loaded into FWoA in the same way.
+            // Checking only a few of them is good enough
+            expect.arrayContaining([
+                {
+                    name: 'ethnicity',
+                    definition: 'http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity',
+                    type: 'token',
+                    documentation: 'Returns patients with an ethnicity extension matching the specified code.',
+                },
+                {
+                    name: 'race',
+                    definition: 'http://hl7.org/fhir/us/core/SearchParameter/us-core-race',
+                    type: 'token',
+                    documentation: 'Returns patients with a race extension matching the specified code.',
+                },
+                {
+                    name: 'given',
+                    definition: 'http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given',
+                    type: 'string',
+                    documentation:
+                        'A portion of the given name of the patient<br />\n' +
+                        '<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n' +
+                        '<a href="http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html">capabilitystatement-expectation</a>\n' +
+                        ' extension to formally express implementer conformance expectations for these elements:<br />\n' +
+                        ' - multipleAnd<br />\n' +
+                        ' - multipleOr<br />\n' +
+                        ' - comparator<br />\n' +
+                        ' - modifier<br />\n' +
+                        ' - chain<br />\n' +
+                        '\n' +
+                        ' ',
+                },
+            ]),
+        );
+
+        // console.log(usCorePatientSearchParams);
+    });
+
+    test('query using search parameters', async () => {
+        const chance = new Chance();
+        const raceCode = chance.word({ length: 15 });
+        const ethnicityCode = chance.word({ length: 15 });
+        const usCorePatient = {
+            ...randomPatient(),
+            ...{
+                extension: [
+                    {
+                        extension: [
+                            {
+                                url: 'ombCategory',
+                                valueCoding: {
+                                    system: 'urn:oid:2.16.840.1.113883.6.238',
+                                    code: raceCode,
+                                    display: 'White',
+                                },
+                            },
+                        ],
+                        url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+                    },
+                    {
+                        extension: [
+                            {
+                                url: 'detailed',
+                                valueCoding: {
+                                    system: 'urn:oid:2.16.840.1.113883.6.238',
+                                    code: ethnicityCode,
+                                    display: 'Mexican',
+                                },
+                            },
+                        ],
+                        url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
+                    },
+                ],
+            },
+        };
+
+        const testPatient: ReturnType<typeof randomPatient> = (await client.post('Patient', usCorePatient)).data;
+
+        // wait for the patient to be asynchronously written to ES
+        await waitForExpect(
+            expectResourceToBePartOfSearchResults.bind(
+                null,
+                client,
+                {
+                    url: 'Patient',
+                    params: {
+                        _id: testPatient.id,
+                    },
+                },
+                testPatient,
+            ),
+            20000,
+            3000,
+        );
+
+        const p = (params: any) => ({ url: 'Patient', params });
+        const testsParams = [
+            p({ race: raceCode }),
+            p({ ethnicity: ethnicityCode }),
+            p({ given: testPatient.name[0].given[0] }), // US Core "given" is functionally the same as the base FHIR "given"
+        ];
+
+        // run tests serially for easier debugging and to avoid throttling
+        // eslint-disable-next-line no-restricted-syntax
+        for (const testParams of testsParams) {
+            // eslint-disable-next-line no-await-in-loop
+            await expectResourceToBePartOfSearchResults(client, testParams, testPatient);
+        }
+    });
+});

--- a/integration-tests/search.test.ts
+++ b/integration-tests/search.test.ts
@@ -4,33 +4,9 @@
  */
 import { AxiosInstance } from 'axios';
 import waitForExpect from 'wait-for-expect';
-import { getFhirClient, randomPatient } from './utils';
+import { expectResourceToBePartOfSearchResults, getFhirClient, randomPatient } from './utils';
 
 jest.setTimeout(60 * 1000);
-
-const expectResourceToBePartOfSearchResults = async (
-    client: AxiosInstance,
-    search: { url: string; params?: any },
-    resource: any,
-) => {
-    console.log('Searching with params:', search);
-    await expect(
-        (async () => {
-            return (
-                await client.get(search.url, {
-                    params: search.params,
-                })
-            ).data;
-        })(),
-    ).resolves.toMatchObject({
-        resourceType: 'Bundle',
-        entry: expect.arrayContaining([
-            expect.objectContaining({
-                resource,
-            }),
-        ]),
-    });
-};
 
 describe('search', () => {
     let client: AxiosInstance;

--- a/integration-tests/types.ts
+++ b/integration-tests/types.ts
@@ -1,0 +1,125 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface Implementation {
+    description: string;
+    url: string;
+}
+
+export enum Code {
+    Create = 'create',
+    Delete = 'delete',
+    Read = 'read',
+    SearchType = 'search-type',
+    Transaction = 'transaction',
+    Update = 'update',
+    Vread = 'vread',
+}
+
+export interface Interaction {
+    code: Code;
+}
+
+export interface Operation {
+    name: string;
+    definition: string;
+}
+
+export enum Conditional {
+    NotSupported = 'not-supported',
+}
+
+export enum Type {
+    Date = 'date',
+    Number = 'number',
+    Quantity = 'quantity',
+    Reference = 'reference',
+    String = 'string',
+    Token = 'token',
+    URI = 'uri',
+}
+
+export interface SearchParam {
+    name: string;
+    definition: string;
+    type: Type;
+    documentation: string;
+}
+
+export enum Versioning {
+    Versioned = 'versioned',
+}
+
+export interface ExtensionExtension {
+    url: string;
+    valueUri: string;
+}
+
+export interface SecurityExtension {
+    url: string;
+    extension: ExtensionExtension[];
+}
+
+export interface Coding {
+    system: string;
+    code: string;
+}
+
+export interface Service {
+    coding: Coding[];
+}
+
+export interface Security {
+    cors: boolean;
+    service: Service[];
+    extension: SecurityExtension[];
+    description: string;
+}
+
+export interface Software {
+    name: string;
+    version: string;
+}
+
+export interface Resource {
+    type: string;
+    interaction: Interaction[];
+    versioning: Versioning;
+    readHistory: boolean;
+    updateCreate: boolean;
+    conditionalCreate: boolean;
+    conditionalRead: Conditional;
+    conditionalUpdate: boolean;
+    conditionalDelete: Conditional;
+    searchParam?: SearchParam[];
+    searchInclude?: string[];
+    searchRevInclude?: string[];
+}
+
+export interface REST {
+    mode: string;
+    documentation: string;
+    security: Security;
+    resource: Resource[];
+    interaction: Interaction[];
+    operation: Operation[];
+}
+
+export interface CapabilityStatement {
+    resourceType: string;
+    name: string;
+    title: string;
+    description: string;
+    purpose: string;
+    status: string;
+    date: Date;
+    publisher: string;
+    kind: string;
+    software: Software;
+    implementation: Implementation;
+    fhirVersion: string;
+    format: string[];
+    rest: REST[];
+}

--- a/integration-tests/utils.ts
+++ b/integration-tests/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import * as AWS from 'aws-sdk';
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import { Chance } from 'chance';
 
 export const getFhirClient = async () => {
@@ -112,4 +112,28 @@ export const randomPatient = () => {
             reference: `Organization/${chance.word({ length: 15 })}`,
         },
     };
+};
+
+export const expectResourceToBePartOfSearchResults = async (
+    client: AxiosInstance,
+    search: { url: string; params?: any },
+    resource: any,
+) => {
+    console.log('Searching with params:', search);
+    await expect(
+        (async () => {
+            return (
+                await client.get(search.url, {
+                    params: search.params,
+                })
+            ).data;
+        })(),
+    ).resolves.toMatchObject({
+        resourceType: 'Bundle',
+        entry: expect.arrayContaining([
+            expect.objectContaining({
+                resource,
+            }),
+        ]),
+    });
 };


### PR DESCRIPTION
Description of changes:

GH actions will download US Core and Compile it so that it is loaded by FWoA. Integ tests then will validate that US core specific search params are working. But right now, for search parameters alone, it is fine

There were some discussions earlier during the design review about whether or not we nee a separate environment for IGs integ tests. For search tests alone it's totally fine to use the same environment. We may revisit that if/when the IGs implementation brings up different pieces of infrastructure.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
