### PR TITLE
fix: Update oauth2ApiEndpoint

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -17,7 +17,7 @@ custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   issuerEndpoint: ${opt:issuerEndpoint, 'https://dev-80793861.okta.com/oauth2/default'}
-  oAuth2ApiEndpoint: ${opt:oAuth2ApiEndpoint, 'https://dev-80793861.okta.com/oauth2/default/v1'}
+  oAuth2ApiEndpoint: ${opt:oAuth2ApiEndpoint, 'https://dev-80793861.okta.com/oauth2/aus4az2kcEfXCbGmI5d6/v1'}
   patientPickerEndpoint: ${opt:patientPickerEndpoint, 'https://ifhprna212.execute-api.us-east-2.amazonaws.com/sandbox'}
 
 provider:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The AuthZ server that was set up in Okta and was also deployed by Patient Picket has the id `aus4az2kcEfXCbGmI5d6`, not `default`. 

This change is needed so that we get the proper `jwks` at https://dev-80793861.okta.com/oauth2/aus4az2kcEfXCbGmI5d6/v1/keys not https://dev-80793861.okta.com/oauth2/default/v1/keys.

This will allow us to make authenticated requests to the FHIR Server.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
