### PR TITLE
test: Only merge smart-develop to smart-mainline if custom-integration-tests and inferno-test passes

### DIFF
--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -127,7 +127,7 @@ jobs:
           SMART_API_KEY: ${{ secrets.SMART_API_KEY}}
         run: yarn int-test
   merge-develop-to-smart-mainline:
-    needs: inferno-test
+    needs: custom-integration-tests
     name: Merge develop to mainline
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
test: Only merge smart-develop to smart-mainline if custom-integration-tests and inferno-test passes



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
