### PR TITLE
feat: add useHapiValidator CFN parameter

### DIFF
--- a/javaHapiValidatorLambda/.gitignore
+++ b/javaHapiValidatorLambda/.gitignore
@@ -12,3 +12,4 @@ target
 
 # Serverless directories
 .serverless
+/src/main/resources/implementationGuides/

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -19,6 +19,7 @@ custom:
   region: ${opt:region, self:provider.region}
   oauthRedirect: ${opt:oauthRedirect, 'http://localhost'}
   config: ${file(serverless_config.json)}
+  useHapiValidator: ${opt:useHapiValidator, 'false'}
 
 provider:
   name: aws
@@ -42,6 +43,11 @@ provider:
       !Join ['', ['https://', !Ref UserPoolDomain, !Sub '.auth.${AWS::Region}.amazoncognito.com/oauth2']]
     EXPORT_RESULTS_BUCKET: !Ref BulkExportResultsBucket
     EXPORT_RESULTS_SIGNER_ROLE_ARN: !GetAtt ExportResultsSignerRole.Arn
+    VALIDATOR_LAMBDA_ALIAS:
+      !If
+        - isUsingHapiValidator
+        - Fn::ImportValue: "fhir-service-validator-lambda-${self:custom.stage}"
+        - !Ref AWS::NoValue
   apiKeys:
     - name: 'developer-key-${self:custom.stage}' # Full name must be known at package-time
       description: Key for developer to access the FHIR Api
@@ -183,9 +189,17 @@ resources:
         Type: Number
         Default: 5
         Description: Number of Glue workers to use during an Export job.
+      UseHapiValidator:
+        Type: String
+        Default: ${self:custom.useHapiValidator}
+        AllowedValues:
+          - 'true'
+          - 'false'
+        Description: whether or not to use an already deployed HAPI Validator
   - Conditions:
       isDev: !Equals [!Ref Stage, 'dev']
       isNotDev: !Not [Condition: isDev]
+      isUsingHapiValidator: !Equals [!Ref UseHapiValidator, 'true']
   - Resources:
       ResourceDynamoDBTableV2:
         Type: AWS::DynamoDB::Table
@@ -413,6 +427,14 @@ resources:
                       - 'states:StartExecution'
                     Resource:
                       - !Ref BulkExportStateMachine
+                  - !If
+                    - isUsingHapiValidator
+                    - Effect: Allow
+                      Action:
+                        - 'lambda:InvokeFunction'
+                      Resource:
+                        - Fn::ImportValue: "fhir-service-validator-lambda-${self:custom.stage}"
+                    - !Ref AWS::NoValue
       DdbToEsLambdaRole:
         Type: AWS::IAM::Role
         Properties:

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,14 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { FhirConfig, FhirVersion, stubs, BASE_R4_RESOURCES, BASE_STU3_RESOURCES } from 'fhir-works-on-aws-interface';
+import {
+    FhirConfig,
+    FhirVersion,
+    stubs,
+    BASE_R4_RESOURCES,
+    BASE_STU3_RESOURCES,
+    Validator,
+} from 'fhir-works-on-aws-interface';
 import { ElasticSearchService } from 'fhir-works-on-aws-search-es';
 import { RBACHandler } from 'fhir-works-on-aws-authz-rbac';
 import {
@@ -14,6 +21,7 @@ import {
     DynamoDbUtil,
 } from 'fhir-works-on-aws-persistence-ddb';
 import JsonSchemaValidator from 'fhir-works-on-aws-routing/lib/router/validation/jsonSchemaValidator';
+import HapiFhirLambdaValidator from 'fhir-works-on-aws-routing/lib/router/validation/hapiFhirLambdaValidator';
 import RBACRules from './RBACRules';
 import { loadImplementationGuides } from './implementationGuides/loadCompiledIGs';
 
@@ -24,6 +32,16 @@ const baseResources = fhirVersion === '4.0.1' ? BASE_R4_RESOURCES : BASE_STU3_RE
 const authService = IS_OFFLINE ? stubs.passThroughAuthz : new RBACHandler(RBACRules(baseResources), fhirVersion);
 const dynamoDbDataService = new DynamoDbDataService(DynamoDb);
 const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb);
+
+// Configure the input validators. Validators run in the order that they appear on the array. Use an empty array to disable input validation.
+const validators: Validator[] = [];
+if (process.env.VALIDATOR_LAMBDA_ALIAS) {
+    // The HAPI FHIR Validator must be deployed separately. It is the recommended choice when using implementation guides.
+    validators.push(new HapiFhirLambdaValidator(process.env.VALIDATOR_LAMBDA_ALIAS));
+} else {
+    // The JSON Schema Validator is simpler and is a good choice for testing the FHIR server with minimal configuration.
+    validators.push(new JsonSchemaValidator(fhirVersion));
+}
 
 const esSearch = new ElasticSearchService(
     [
@@ -75,7 +93,7 @@ export const fhirConfig: FhirConfig = {
         // Unused at this point
         level: 'error',
     },
-    validators: [new JsonSchemaValidator(fhirVersion)],
+    validators,
     profile: {
         systemOperations: ['transaction'],
         bundle: dynamoDbBundleService,


### PR DESCRIPTION
Description of changes:

Add the `useHapiValidator` parameter that sets up permissions and env variables in order to call the HAPI validator Lambda. This allows customers to more easily opt in to use the HAPI Validator without having a separate branch.

The deployment sequence would be:
```bash
#fhir-works-on-aws-deployment/javaHapiValidatorLambda
mvn clean install #serverless does not auto-build java project like with js
serverless deploy

#fhir-works-on-aws-deployment
serverless deploy --useHapiValidator true
```

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [n/a] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
