### PR TITLE
feat: specify paths to IG resources

### DIFF
--- a/javaHapiValidatorLambda/pom.xml
+++ b/javaHapiValidatorLambda/pom.xml
@@ -127,6 +127,23 @@
     </dependencies>
 
     <build>
+        <resources>
+            <!-- Copy the implementation guides packages from resources folder -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>implementationGuides/*/*.json</include>
+                    <include>log4j2.xml</include>
+                </includes>
+            </resource>
+            <!-- Copy the implementation guides packages from parent folder -->
+            <resource>
+                <directory>..</directory>
+                <includes>
+                    <include>implementationGuides/*/*.json</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Description of changes:

By default maven copies all files under `src/main/resources` into the jar. Changing it to be more specific to only copy IG json files and to also copy the IG files from the parent folder.  

This way, customers only need to copy IGs into the `implementationGuides` folder at the root of the deployment package and things will just work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
