### PR TITLE
fix: http errors from routing dependency

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -19,6 +19,8 @@ custom:
   oauthRedirect: ${opt:oauthRedirect, 'http://localhost'}
   config: ${file(serverless_config.json)}
   bundle:
+    externals:
+      - fhir-works-on-aws-routing
     packager: yarn
     copyFiles: # Copy any additional files to the generated package
       - from: 'bulkExport/glueScripts/export-script.py'


### PR DESCRIPTION
Issue #, if available:

Description of changes:
When errors are thrown, the routing package is not catching it properly, hence the failing tests here.
https://github.com/awslabs/fhir-works-on-aws-deployment/runs/2083256307

Errors as shown in CWL
```
ERROR	Unhandled Error TypeError: http_errors_1.default.isHttpError is not a function
    at httpErrorHandler (/var/task/src/webpack:/Volumes/unix/workplace/fhir-works-on-aws-deployment/node_modules/fhir-works-on-aws-routing/lib/router/routes/errorHandling.js:51:1)
```

New changes were testes against crucible and custom integration tests. These tests passed in developer deployed environment. 


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
