### PR TITLE
chore: update deploy script for working with local packages

### DIFF
--- a/scripts/fhir-works-deploy.sh
+++ b/scripts/fhir-works-deploy.sh
@@ -1,12 +1,5 @@
 #!/bin/bash -e
 
-read -n 1 -p "This script adds local dependencies to your 'fhir-works-on-aws-deployment' package during build. It will then revert your 'package.json' to the last version of the package in Git. Have you committed the 'package.json' file in your 'fhir-works-on-aws-deployment' package  to Git (y/n)?" answer
-if [ $answer != "y" ]
-then
-  printf "\nPlease commit the package.json file in  your 'fhir-works-on-aws-deployment' package to Git"
-  exit
-fi
-
 packages=(
 "fhir-works-on-aws-authz-smart"
 "fhir-works-on-aws-persistence-ddb"
@@ -36,19 +29,15 @@ done
 
 printf "\nFor deployment package, remove old pregenerated files, add all other packages as dependencies, install all dependencies again"
 cd fhir-works-on-aws-deployment
-rm -rf node_modules build/* dist/* 
+rm -rf node_modules build/* dist/*  .yalc
 yalc add fhir-works-on-aws-interface
 for i in "${packages[@]}"
 do
   yalc add $i
 done
+sed -i.bak 's#file:.yalc#./.yalc#g' package.json && rm package.json.bak
 yarn install
 
-
-printf "\nReverting package.json changes. Serverless pack does not play well with local dependencies added by yalc\n"
-
-git checkout package.json
-
-printf "\nYou can now go to your deployment package and deploy using serverless. You can deploy using the command 'serverless deploy --aws-profile <PROFILE> --stage <STAGE>'" 
+printf "\nYou can now go to your deployment package and deploy using serverless. You can deploy using the command 'serverless deploy --aws-profile <PROFILE> --stage <STAGE>'"
 
 cd ..


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Same PR as [this](https://github.com/awslabs/fhir-works-on-aws-deployment/pull/245), but for `smart-develop` branch

Update fhir-works-deploy.sh script to allow deploying local package.

serverless-webpack isn't handing file reference correctly, therefore we need to update the references in package.json.
More info here

Without this update, trying to deploy would result in this error during the build process.

Serverless: Package lock found - Using locked versions
Serverless: Packing external modules: fhir-works-on-aws-routing@5.0.0
  Error --------------------------------------------------
  Error: yarn install --frozen-lockfile --non-interactive failed with code 1


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
