### PR TITLE
fix: copy IG files to webpack deployment package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ yalc.lock
 
 /implementationGuides
 /compiledImplementationGuides
+/.webpack/

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -5,11 +5,6 @@
 
 service: fhir-service
 
-package:
-  include:
-    - bulkExport/glueScripts/export-script.py
-    - compiledImplementationGuides/*
-
 custom:
   oldResourceTableName: 'resource-${self:custom.stage}'
   resourceTableName: 'resource-db-${self:custom.stage}'
@@ -27,6 +22,8 @@ custom:
     copyFiles: # Copy any additional files to the generated package
       - from: 'bulkExport/glueScripts/export-script.py'
         to: './bulkExport/glueScripts/export-script.py'
+      - from: 'compiledImplementationGuides/*'
+        to: './'
 
 provider:
   name: aws

--- a/src/implementationGuides/loadCompiledIGs.ts
+++ b/src/implementationGuides/loadCompiledIGs.ts
@@ -20,7 +20,7 @@ export const loadImplementationGuides = (
     implementationGuidesPath?: PathLike,
 ): any[] | undefined => {
     const resolvedImplementationGuidesPath =
-        implementationGuidesPath ?? path.join(__dirname, '..', '..', COMPILED_IGS_DIRECTORY);
+        implementationGuidesPath ?? path.join(__dirname, '..', COMPILED_IGS_DIRECTORY);
 
     const igsPath = path.join(resolvedImplementationGuidesPath.toString(), `${moduleName}.json`);
 


### PR DESCRIPTION
Description of changes:
Now that we are using webpack, some minor changes were needed to properly copy and load the IG files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
