### PR TITLE
Terminate install.sh when serverless deploy fails

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -312,6 +312,12 @@ echo -e "\n\nFHIR Works is deploying. A fresh install will take ~20 mins\n\n"
 ## Deploy to stated region
 serverless deploy --region $region --stage $stage
 
+if [[ $? != 0 ]]; then
+    echo "Deploying failed, check above error."
+    echo "Terminating..."
+    exit 1
+fi
+
 ## Output to console and to file Info_Output.yml.  tee not used as it removes the output highlighting.
 echo -e "Deployed Successfully.\n"
 touch Info_Output.yml


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Terminate install.sh script whenever `serverless deploy ...` fails.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
