### PR TITLE
chore: fix gh merge workflow to do ff-only

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -139,9 +139,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Merge to mainline branch
-        uses: devmasx/merge-branch@v1.1.0
+        uses: robotology/gh-action-nightly-merge@v1.3.2
         with:
-          type: now
-          target_branch: 'mainline'
+          # branch names seem reversed since this action was originally meant for nightly merges into a development branch
+          # merges `stable_branch` into `development_branch`
+          stable_branch: 'develop'
+          development_branch: 'mainline'
+          allow_ff: true
+          ff_only: true
         env:
-          GITHUB_TOKEN: ${{secrets.MERGE_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Our git history is a mess due to the way merge commits are created in gh actions.

This is confusing and makes develop look like if it was outdated:
>(on develop branch)This branch is 8 commits behind mainline. 

```
186590e08e87:fhir-works-on-aws-deployment nestorba$ git log mainline --oneline --graph
*   b68d638 (tag: v2.1.0, mainline) Merge f0ec3b40150e860a0a8969bacf304c8d3ffa06eb into mainline
|\  
| * f0ec3b4 chore: Bump package.json version (#115)
* |   43069fd Merge 000fb80aff9f49ce92a54474ca61d3888b59b9da into mainline
|\ \  
| |/  
| * 000fb80 feat: 2.1.0 release (#113)
* |   95a41cf (tag: v2.0.0) Merge df76bdf085dcde70670f7611c1255762cf292a3d into mainline
|\ \  
| |/  
| * df76bdf fix: Update DynamoDB sort key from String to Num (#112)
* |   07a04b0 Merge 39e94a781f0b9f68f2d7d80c53c7398418b67a81 into mainline
|\ \  
| |/  
| * 39e94a7 docs: Add instructions for local development and deployment (#107)
* |   c522f75 Merge b1b59a38bff1688d178df5b8545e05d64422edc9 into mainline
|\ \  
| |/  
| * b1b59a3 Security: node-fetch package had to be updated (#105)
* |   ec340a7 (tag: v1.1.0) Merge d321609f4ab0a006a671ed533f6f69a6c7088888 into mainline
|\ \  
| |/  
| * d321609 doc: update version & changelog (#102)
* |   ca352ef Merge 63d6004a3d878a9e3386e96559936c7f7e0bc76a into mainline
```

I switched to a merge action that is much more configurable and allows to force fast forward merges to keep a linear history.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
