### PR TITLE
chore: use our own script instead of merge action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -138,14 +138,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Merge to mainline branch
-        uses: robotology/gh-action-nightly-merge@v1.3.2
-        with:
-          # branch names seem reversed since this action was originally meant for nightly merges into a development branch
-          # merges `stable_branch` into `development_branch`
-          stable_branch: 'develop'
-          development_branch: 'mainline'
-          allow_ff: true
-          ff_only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge to mainline
+          run: |
+            git checkout mainline
+            echo
+            echo "  Attempting to merge the 'develop' branch ($(git log -1 --pretty=%H develop))"
+            echo "  into the 'mainline' branch ($(git log -1 --pretty=%H mainline))"
+            echo
+            git merge --ff-only --no-edit develop
+            git push origin mainline


### PR DESCRIPTION
Previous PR didn't work as expected https://github.com/awslabs/fhir-works-on-aws-deployment/pull/264
Turns out merge related actions are not so great, it's easier to just have our own small merge script.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
