### PR TITLE
ci: use HAPI validator on integ tests

### DIFF
--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -84,7 +84,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SMART_AWS_SECRET_ACCESS_KEY }}
         run: |
           yarn install
-          serverless deploy --stage dev --region us-east-2 --issuerEndpoint ${{ secrets.SMART_ISSUER_ENDPOINT }} --oAuth2ApiEndpoint ${{ secrets.SMART_OAUTH2_API_ENDPOINT }} --patientPickerEndpoint ${{ secrets.SMART_PATIENT_PICKER_ENDPOINT }} --conceal
+          serverless deploy --stage dev --region us-east-2 --issuerEndpoint ${{ secrets.SMART_ISSUER_ENDPOINT }} --oAuth2ApiEndpoint ${{ secrets.SMART_OAUTH2_API_ENDPOINT }} --patientPickerEndpoint ${{ secrets.SMART_PATIENT_PICKER_ENDPOINT }} --useHapiValidator true --conceal
       - name: Deploy auditLogMover
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SMART_AWS_ACCESS_KEY_ID}}


### PR DESCRIPTION
Description of changes:
Integ tests failed since US Core is loaded but the HAPI validator was not being used. This fixes it


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
