### PR TITLE
ci: use correct test credentials

### DIFF
--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -71,8 +71,8 @@ jobs:
         run: yarn run compile-igs
       - name: Deploy Hapi validator
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.SMART_AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SMART_AWS_SECRET_ACCESS_KEY }}
         run: |
           cd javaHapiValidatorLambda
           mvn --batch-mode --update-snapshots --no-transfer-progress clean install


### PR DESCRIPTION
Validator was being deployed on a different account due to mismatching credentials

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
