### PR TITLE
fix: fix unable to locate compiledImplementationGuides/* glob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ serverless_config.json
 yalc.lock
 
 /implementationGuides
-/compiledImplementationGuides
+/compiledImplementationGuides/*
+!/compiledImplementationGuides/gitkeep
 /.webpack/

--- a/yarn.lock
+++ b/yarn.lock
@@ -5765,10 +5765,10 @@ fhir-works-on-aws-persistence-ddb@3.3.0:
     promise.allsettled "^1.0.2"
     uuid "^3.4.0"
 
-fhir-works-on-aws-routing@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-routing/-/fhir-works-on-aws-routing-5.1.0.tgz#72d6d6870195770ad929e1ac9f3c2ceef60ab3e9"
-  integrity sha512-PFsFybMrJIDMH+1iTikT1waZ7J7ha2CBAXS2cqHMP2g4nNsiRClIJAF1Ynj8zOTzWtoem604mjsKG1LZynkIyA==
+fhir-works-on-aws-routing@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-routing/-/fhir-works-on-aws-routing-5.1.1.tgz#b5562b7f5ff636d7284d51965c59d9e323be3101"
+  integrity sha512-C+sTV7p48nEZla9KtIdI4hSfyFPeKm9tsRsML9KZE0JI73MngKChs1XM9HRHfkbTsf/ItF0+Tx8jJ3DrG5y8fQ==
   dependencies:
     "@types/cors" "^2.8.7"
     "@types/express-serve-static-core" "^4.17.2"


### PR DESCRIPTION
Add an empty file to ensure that the `compiledImplementationGuides` folder is commited to git

Note: the updates to `yarn.lock` are changes that were missing from an earlier update to `package.json` 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
