### PR TITLE
fix: exit from installation script if serverless deployment fails

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -310,7 +310,7 @@ fi
 
 echo -e "\n\nFHIR Works is deploying. A fresh install will take ~20 mins\n\n"
 ## Deploy to stated region
-serverless deploy --region $region --stage $stage
+serverless deploy --region $region --stage $stage || { echo >&2 "Failed to deploy serverless application."; exit 1; }
 
 ## Output to console and to file Info_Output.yml.  tee not used as it removes the output highlighting.
 echo -e "Deployed Successfully.\n"


### PR DESCRIPTION
Description of changes:
Add check for exit code of `serverless` executable

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
