### PR TITLE
fix: Suppress deprecation warning when writing to Info_Output.yml during installation

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -315,7 +315,7 @@ serverless deploy --region $region --stage $stage || { echo >&2 "Failed to deplo
 ## Output to console and to file Info_Output.yml.  tee not used as it removes the output highlighting.
 echo -e "Deployed Successfully.\n"
 touch Info_Output.yml
-serverless info --verbose --region $region --stage $stage && serverless info --verbose --region $region --stage $stage > Info_Output.yml
+SLS_DEPRECATION_DISABLE=* serverless info --verbose --region $region --stage $stage && SLS_DEPRECATION_DISABLE=* serverless info --verbose --region $region --stage $stage > Info_Output.yml
 #The double call to serverless info was a bugfix from Steven Johnston
     #(may not be needed)
 


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/fhir-works-on-aws-deployment/issues/293

Description of changes:
fix: Suppress deprecation warning when writing to Info_Output.yml during installation

Relevant docs for this config option [here](https://www.serverless.com/framework/docs/deprecations/#how-to-disable-specific-deprecation-logs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
