### PR TITLE
chore: lock down versions of external deployment dependencies

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -67,7 +67,6 @@ function install_dependencies(){
         fi
 
         type -a npm || sudo $PKG_MANAGER install npm -y
-#        type -a serverless || sudo npm install -g serverless </dev/null #without manipulating the stdin, it breaks everything
 
         type -a python3 || sudo $PKG_MANAGER install python3 -y
         type -a pip3 || sudo $PKG_MANAGER install python3-pip -y
@@ -76,17 +75,6 @@ function install_dependencies(){
         type -a yarn 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
             sudo npm install --global yarn@1.22.5
-#            if [ "$basepkg" == "apt-get" ]; then
-#                #This is a weird bug on Ubuntu, 'cmdtest' and 'yarn' have the same alias, so it always installs the wrong package
-#                sudo apt-get remove cmdtest
-#                sudo apt-get remove yarn
-#                curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-#                echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-#            elif [ "$basepkg" == "yum" ]; then
-#                curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
-#            fi
-#            sudo $PKG_MANAGER update
-#            sudo $PKG_MANAGER install yarn -y
         fi
 
         sudo $PKG_MANAGER upgrade -y

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -299,7 +299,7 @@ IAMUserARN=$(aws sts get-caller-identity --query "Arn" --output text)
 
 #TODO: how to stop if not all test cases passed?
 cd ${PACKAGE_ROOT}
-yarn install
+yarn install --frozen-lockfile
 yarn run release
 
 touch serverless_config.json
@@ -383,7 +383,7 @@ echo "You can also do this later manually, if you would prefer."
 echo ""
 if `YesOrNo "Would you like to set the server to archive logs older than 7 days?"`; then
     cd ${PACKAGE_ROOT}/auditLogMover
-    yarn install
+    yarn install --frozen-lockfile
     yarn run serverless deploy --region $region --stage $stage
     cd ${PACKAGE_ROOT}
     echo -e "\n\nSuccess."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -67,7 +67,7 @@ function install_dependencies(){
         fi
 
         type -a npm || sudo $PKG_MANAGER install npm -y
-        type -a serverless || sudo npm install -g serverless </dev/null #without manipulating the stdin, it breaks everything
+#        type -a serverless || sudo npm install -g serverless </dev/null #without manipulating the stdin, it breaks everything
 
         type -a python3 || sudo $PKG_MANAGER install python3 -y
         type -a pip3 || sudo $PKG_MANAGER install python3-pip -y
@@ -75,17 +75,18 @@ function install_dependencies(){
 
         type -a yarn 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
-            if [ "$basepkg" == "apt-get" ]; then
-                #This is a weird bug on Ubuntu, 'cmdtest' and 'yarn' have the same alias, so it always installs the wrong package
-                sudo apt-get remove cmdtest
-                sudo apt-get remove yarn
-                curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-                echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-            elif [ "$basepkg" == "yum" ]; then
-                curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
-            fi
-            sudo $PKG_MANAGER update
-            sudo $PKG_MANAGER install yarn -y
+            sudo npm install --global yarn@1.22.5
+#            if [ "$basepkg" == "apt-get" ]; then
+#                #This is a weird bug on Ubuntu, 'cmdtest' and 'yarn' have the same alias, so it always installs the wrong package
+#                sudo apt-get remove cmdtest
+#                sudo apt-get remove yarn
+#                curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+#                echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+#            elif [ "$basepkg" == "yum" ]; then
+#                curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+#            fi
+#            sudo $PKG_MANAGER update
+#            sudo $PKG_MANAGER install yarn -y
         fi
 
         sudo $PKG_MANAGER upgrade -y
@@ -93,11 +94,10 @@ function install_dependencies(){
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         #sudo -u $SUDO_USER removes brew's error message that brew should not be run as 'sudo'
         type -a brew 2>&1 || { error_msg="ERROR: brew is required to install packages."; return 1; }
-        sudo -u $SUDO_USER brew install node
-        sudo -u $SUDO_USER brew install python
-        sudo -u $SUDO_USER brew install yarn
+        sudo -u $SUDO_USER brew install node@12
+        sudo -u $SUDO_USER brew install python3
+        sudo npm install --global yarn@1.22.5
         sudo pip3 install boto3
-        sudo npm install -g serverless
     else
         error_msg="ERROR: this install script is only supported on Linux or macOS."
         return 1
@@ -110,7 +110,6 @@ function install_dependencies(){
     type -a python3 2>&1 || { error_msg="ERROR: package 'python3' failed to install."; return 1; }
     type -a pip3 2>&1 || { error_msg="ERROR: package 'python3-pip' failed to install."; return 1; }
     type -a yarn 2>&1 || { error_msg="ERROR: package 'yarn' failed to install."; return 1; }
-    type -a serverless 2>&1 || { error_msg="ERROR: package 'serverless' failed to install."; return 1; }
 
     return 0
 }
@@ -279,7 +278,7 @@ fi
 
 if [ "$DOCKER" != "true" ]; then
     echo -e "\nIn order to deploy the server, the following dependencies are required:"
-    echo -e "\t- nodejs\n\t- npm\n\t- python3\n\t- yarn\n\t- serverless"
+    echo -e "\t- nodejs\n\t- npm\n\t- python3\n\t- yarn"
     echo -e "\nThese dependencies will be installed (if not already present)."
     if ! `YesOrNo "Would you like to continue?"`; then
         echo "Exiting..."
@@ -310,12 +309,12 @@ fi
 
 echo -e "\n\nFHIR Works is deploying. A fresh install will take ~20 mins\n\n"
 ## Deploy to stated region
-serverless deploy --region $region --stage $stage || { echo >&2 "Failed to deploy serverless application."; exit 1; }
+yarn run serverless deploy --region $region --stage $stage || { echo >&2 "Failed to deploy serverless application."; exit 1; }
 
 ## Output to console and to file Info_Output.yml.  tee not used as it removes the output highlighting.
 echo -e "Deployed Successfully.\n"
 touch Info_Output.yml
-SLS_DEPRECATION_DISABLE=* serverless info --verbose --region $region --stage $stage && SLS_DEPRECATION_DISABLE=* serverless info --verbose --region $region --stage $stage > Info_Output.yml
+SLS_DEPRECATION_DISABLE=* yarn run serverless info --verbose --region $region --stage $stage && SLS_DEPRECATION_DISABLE=* yarn run serverless info --verbose --region $region --stage $stage > Info_Output.yml
 #The double call to serverless info was a bugfix from Steven Johnston
     #(may not be needed)
 
@@ -385,7 +384,7 @@ echo ""
 if `YesOrNo "Would you like to set the server to archive logs older than 7 days?"`; then
     cd ${PACKAGE_ROOT}/auditLogMover
     yarn install
-    serverless deploy --region $region --stage $stage
+    yarn run serverless deploy --region $region --stage $stage
     cd ${PACKAGE_ROOT}
     echo -e "\n\nSuccess."
 fi

--- a/scripts/win_install.ps1
+++ b/scripts/win_install.ps1
@@ -69,7 +69,6 @@ function Install-Dependencies {
     }
     choco install -y nodejs.install --version=12.18.3 #also installs npm by default
     choco install -y python3
-#     choco install -y yarn
     npm install --global yarn@1.22.5
 
     #fix path issues

--- a/scripts/win_install.ps1
+++ b/scripts/win_install.ps1
@@ -69,7 +69,8 @@ function Install-Dependencies {
     }
     choco install -y nodejs.install --version=12.18.3 #also installs npm by default
     choco install -y python3
-    choco install -y yarn
+#     choco install -y yarn
+    npm install --global yarn@1.22.5
 
     #fix path issues
     $oldpath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
@@ -228,7 +229,7 @@ if ($already_deployed){
         }
     } until ($response -eq 0)
 
-    if ($fail) { yarn serverless-remove }
+    if ($fail) { yarn run serverless remove }
 }
 
 
@@ -250,7 +251,7 @@ Install-Dependencies
 $IAMUserARN=(Get-STSCallerIdentity).Arn
 
 Set-Location $rootDir
-yarn install
+yarn install --frozen-lockfile
 #yarn run release 
 #eslint isnt working correctly on Windows. Currently investigating.
 yarn run build
@@ -266,7 +267,7 @@ if ($SEL -eq $null){
 
 Write-Host "`n`nDeploying FHIR Server"
 Write-Host "(This may take some time, usually ~20-30 minutes)`n`n" 
-yarn serverless-deploy --region $region --stage $stage
+yarn run serverless deploy --region $region --stage $stage
 
 if (-Not ($?) ) {
     Write-Host "Setting up FHIR Server failed. Please try again later."
@@ -276,7 +277,7 @@ Write-Host "Deployed Successfully.`n"
 
 rm Info_Output.yml
 fc >> Info_Output.yml
-yarn serverless-info --verbose --region $region --stage $stage | Out-File -FilePath .\Info_Output.yml
+yarn run serverless info --verbose --region $region --stage $stage | Out-File -FilePath .\Info_Output.yml
 
 #Read in variables from Info_Output.yml
 $UserPoolId = GetFrom-Yaml "UserPoolId"
@@ -384,8 +385,8 @@ for(;;) {
         Break
     } elseif ($yn -eq 0){ #yes
         Set-Location $rootDir\auditLogMover
-        yarn install
-        yarn serverless-deploy --region $region --stage $stage
+        yarn install --frozen-lockfile
+        yarn run serverless deploy --region $region --stage $stage
         Set-Location $rootDir
         Write-Host "`n`nSuccess."
         Break

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -22,8 +22,8 @@ custom:
     copyFiles: # Copy any additional files to the generated package
       - from: 'bulkExport/glueScripts/export-script.py'
         to: './bulkExport/glueScripts/export-script.py'
-      - from: 'compiledImplementationGuides/*'
-        to: './'
+      - from: 'compiledImplementationGuides'
+        to: './compiledImplementationGuides'
 
 provider:
   name: aws


### PR DESCRIPTION
Description of changes:
Lock down `serverless` and `yarn` version. Serverless is locked down because we're now using the locally installed version of serverless. That version is defined in our `yarn.lock` file.

For `yarn` we are explicitly downloading version `1.22.5`

These script was tested and passed on the following environments
* Ubuntu
* Amazon Linux
* Mac 
* Windows

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
