### PR TITLE
!fix: make glue IAM role more restrictive

### DIFF
--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -33,6 +33,9 @@ Resources:
                   - glue:GetJobRun
                   - glue:BatchStopJobRun
                 Resource: '*'
+                Condition:
+                  StringEquals:
+                    'glue:resourceTag/Name': !Sub '${AWS::StackName}-ExportGlueJob'
               - Effect: Allow
                 Action:
                   - dynamodb:Query
@@ -170,13 +173,15 @@ Resources:
         MaxConcurrentRuns: 2
       DefaultArguments:
         '--TempDir': !Join ['', ['s3://', !Ref BulkExportResultsBucket, '/temp']]
-        '--ddbTableName': '${self:custom.resourceTableName}'
+        '--ddbTableName': !Ref ResourceDynamoDBTableV2
         '--workerType': !Ref ExportGlueWorkerType
         '--numberWorkers': !Ref ExportGlueNumberWorkers
         '--s3OutputBucket': !Ref BulkExportResultsBucket
         '--enable-metrics': 'true'
         '--enable-continuous-cloudwatch-log': 'true'
         '--enable-continuous-log-filter': 'true'
+      Tags:
+        Name: !Sub '${AWS::StackName}-ExportGlueJob'
 
   ExportResultsSignerRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
### Description of changes:

Due to Glue IAM `Resource` definition for the required job actions the `Resource` needs to be `*`. To better lock down the access of this IAM role, it is advised to add a tag to the Glue job then add a condition to the IAM Role.

Good example of this provided by AWS: https://docs.aws.amazon.com/glue/latest/dg/glue-policy-examples-iam-tags.html

NOTE: this is a breaking change due to: https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/306
- Existing FWoA deployments will need to manually add the tag to the existing Glue job: `Name: !Sub '${AWS::StackName}-ExportGlueJob'`

### Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x ] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
