### PR TITLE
fix: Allow running sls offline with Hapi Validator

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,10 +36,11 @@ Once the script has finished running, you can run `yarn watch` in the directory 
 
 If you're using [Implementation Guides](./USING_IMPLEMENTATION_GUIDES.md), then follow these steps to run FHIR Works with IG locally. You'll need to provide the `OFFLINE_LAMBDA_VALIDATOR_ALIAS`.
 
-Run this command in the `deployment` package directory to set up your local environment:
+Run this command in the `deployment` package directory to start your local environment:
 
 `AWS_ACCESS_KEY_ID=<Access-Key> AWS_SECRET_ACCESS_KEY=<Secret-Key> OFFLINE_BINARY_BUCKET=<FHIRBinaryBucket> OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT=<ElasticSearchDomainEndpoint> OFFLINE_VALIDATOR_LAMBDA_ALIAS=<ValidatorLambdaAlias> serverless offline start`
 
+The command above runs the local FHIR server with the appropriate environment variables.
 
 If you don't know the value for `OFFLINE_BINARY_BUCKET`,`OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT`, and `OFFLINE_VALIDATOR_LAMBDA_ALIAS` value, run the following command in the deployment package directory: `serverless info --verbose`
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,17 @@ Once the script has finished running, you can run `yarn watch` in the directory 
 
 `AWS_ACCESS_KEY_ID=<Access-Key> AWS_SECRET_ACCESS_KEY=<Secret-Key> OFFLINE_BINARY_BUCKET=<FHIRBinaryBucket> OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT=<ElasticSearchDomainEndpoint> serverless offline start`
 
-If you don't know the `OFFLINE_BINARY_BUCKET` and `OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT` value, you can run `serverless info --verbose` in the deployment package directory.
+### Local Development with Implementation Guides
+
+If you're using [Implementation Guides](./USING_IMPLEMENTATION_GUIDES.md) then follow the steps below to run Fhir Works with IG locally. You'll need to provide the `OFFLINE_LAMBDA_VALIDATOR_ALIAS`.
+
+Run this command in the `deployment` package directory to spin up your local environment:
+
+`AWS_ACCESS_KEY_ID=<Access-Key> AWS_SECRET_ACCESS_KEY=<Secret-Key> OFFLINE_BINARY_BUCKET=<FHIRBinaryBucket> OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT=<ElasticSearchDomainEndpoint> OFFLINE_VALIDATOR_LAMBDA_ALIAS=<ValidatorLambdaAlias> serverless offline start`
+
+
+If you don't know the `OFFLINE_BINARY_BUCKET`,`OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT`, and `OFFLINE_VALIDATOR_LAMBDA_ALIAS` value, you can run `serverless info --verbose` in the deployment package directory.
+
 
 ## Deploy Local Packages to AWS
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,14 +34,14 @@ Once the script has finished running, you can run `yarn watch` in the directory 
 
 ### Local Development with Implementation Guides
 
-If you're using [Implementation Guides](./USING_IMPLEMENTATION_GUIDES.md) then follow the steps below to run Fhir Works with IG locally. You'll need to provide the `OFFLINE_LAMBDA_VALIDATOR_ALIAS`.
+If you're using [Implementation Guides](./USING_IMPLEMENTATION_GUIDES.md), then follow these steps to run FHIR Works with IG locally. You'll need to provide the `OFFLINE_LAMBDA_VALIDATOR_ALIAS`.
 
-Run this command in the `deployment` package directory to spin up your local environment:
+Run this command in the `deployment` package directory to set up your local environment:
 
 `AWS_ACCESS_KEY_ID=<Access-Key> AWS_SECRET_ACCESS_KEY=<Secret-Key> OFFLINE_BINARY_BUCKET=<FHIRBinaryBucket> OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT=<ElasticSearchDomainEndpoint> OFFLINE_VALIDATOR_LAMBDA_ALIAS=<ValidatorLambdaAlias> serverless offline start`
 
 
-If you don't know the `OFFLINE_BINARY_BUCKET`,`OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT`, and `OFFLINE_VALIDATOR_LAMBDA_ALIAS` value, you can run `serverless info --verbose` in the deployment package directory.
+If you don't know the value for `OFFLINE_BINARY_BUCKET`,`OFFLINE_ELASTICSEARCH_DOMAIN_ENDPOINT`, and `OFFLINE_VALIDATOR_LAMBDA_ALIAS` value, run the following command in the deployment package directory: `serverless info --verbose`
 
 
 ## Deploy Local Packages to AWS

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -688,6 +688,11 @@ resources:
           ]
         Export:
           Name: !Join ['-', [CloudwatchExecutionLogGroup, !Ref Stage, Arn]]
+      ValidatorLambdaAlias:
+        Condition: isUsingHapiValidator
+        Description: Arn of Hapi Validator lambda
+        Value:
+          Fn::ImportValue: "fhir-service-validator-lambda-${self:custom.stage}"
 
 plugins:
   - serverless-step-functions

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,9 +35,12 @@ const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb);
 
 // Configure the input validators. Validators run in the order that they appear on the array. Use an empty array to disable input validation.
 const validators: Validator[] = [];
-if (process.env.VALIDATOR_LAMBDA_ALIAS) {
+if (process.env.VALIDATOR_LAMBDA_ALIAS && process.env.VALIDATOR_LAMBDA_ALIAS !== '[object Object]') {
     // The HAPI FHIR Validator must be deployed separately. It is the recommended choice when using implementation guides.
     validators.push(new HapiFhirLambdaValidator(process.env.VALIDATOR_LAMBDA_ALIAS));
+} else if (process.env.OFFLINE_VALIDATOR_LAMBDA_ALIAS) {
+    // Allows user to run sls offline with custom provided HAPI Lambda
+    validators.push(new HapiFhirLambdaValidator(process.env.OFFLINE_VALIDATOR_LAMBDA_ALIAS));
 } else {
     // The JSON Schema Validator is simpler and is a good choice for testing the FHIR server with minimal configuration.
     validators.push(new JsonSchemaValidator(fhirVersion));


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Users can run `sls offline` with HAPI Validator by providing `OFFLINE_VALIDATOR_LAMBDA_ALIAS` as an env variable
* Updated `serverless.yml` to output `validatorLambdaAlias`
* Updated docs

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
