### PR TITLE
feat: add tenantId attribute to Cognito user pool

### DIFF
--- a/cloudformation/cognito.yaml
+++ b/cloudformation/cognito.yaml
@@ -22,6 +22,8 @@ Resources:
           Required: true
         - AttributeDataType: String
           Name: cc_confirmed
+        - AttributeDataType: String
+          Name: tenantId
   UserPoolClient:
     Type: AWS::Cognito::UserPoolClient
     Properties:

--- a/scripts/init-auth.py
+++ b/scripts/init-auth.py
@@ -4,6 +4,7 @@
 """
 import boto3
 import sys
+import json
 
 client = boto3.client('cognito-idp', region_name=sys.argv[2])
 '''
@@ -21,5 +22,4 @@ response = client.initiate_auth(
     ClientId=sys.argv[1]
 )
 
-sessionid = response['AuthenticationResult']['AccessToken']
-print(sessionid)
+print(json.dumps(response['AuthenticationResult'], indent=2))

--- a/scripts/provision-user.py
+++ b/scripts/provision-user.py
@@ -5,7 +5,7 @@
 
 import boto3
 import sys
-
+import json
 
 '''
 example run:
@@ -15,9 +15,11 @@ python3 provision-user.py us-west-2_yk8jbgpWM 12pgvi3gsl32qp9h8lg130arr0 us-west
 
 client = boto3.client('cognito-idp', region_name=sys.argv[3])
 
+USERNAME = 'workshopuser'
+
 response = client.admin_create_user(
     UserPoolId=sys.argv[1],
-    Username='workshopuser',
+    Username=USERNAME,
     UserAttributes=[
         {
             'Name': 'email',
@@ -26,6 +28,10 @@ response = client.admin_create_user(
         {
             'Name': 'email_verified',
             'Value': 'True'
+        },
+        {
+            'Name': 'custom:tenantId',
+            'Value': 'tenant1'
         }
 
     ],
@@ -42,7 +48,7 @@ response = client.admin_create_user(
 response = client.initiate_auth(
     AuthFlow='USER_PASSWORD_AUTH',
     AuthParameters={
-        'USERNAME': 'workshopuser',
+        'USERNAME': USERNAME,
         'PASSWORD': 'Master123!'
     },
 
@@ -55,26 +61,25 @@ response = client.respond_to_auth_challenge(
     ChallengeName='NEW_PASSWORD_REQUIRED',
     Session=sessionid,
     ChallengeResponses={
-        'USERNAME': 'workshopuser',
+        'USERNAME': USERNAME,
         'NEW_PASSWORD': 'Master123!'
     }
 )
 
 response = client.admin_add_user_to_group(
     UserPoolId=sys.argv[1],
-    Username='workshopuser',
+    Username=USERNAME,
     GroupName='practitioner'
 )
 
 response = client.initiate_auth(
     AuthFlow='USER_PASSWORD_AUTH',
     AuthParameters={
-        'USERNAME': 'workshopuser',
+        'USERNAME': USERNAME,
         'PASSWORD': 'Master123!'
     },
 
     ClientId=sys.argv[2]
 )
 
-sessionid = response['AuthenticationResult']['AccessToken']
-print(sessionid)
+print(json.dumps(response['AuthenticationResult'], indent=2))

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -81,10 +81,6 @@ functions:
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId: !Ref ApiGatewayAuthorizer
-            scopes: # must have both scopes
-              - 'openid'
-              - 'profile'
-              - 'aws.cognito.signin.user.admin'
           method: ANY
           path: /
           private: true
@@ -92,10 +88,6 @@ functions:
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId: !Ref ApiGatewayAuthorizer
-            scopes: # must have both scopes
-              - 'openid'
-              - 'profile'
-              - 'aws.cognito.signin.user.admin'
           method: ANY
           path: '{proxy+}'
           private: true


### PR DESCRIPTION
Description of changes:
Adding tenantId as an attribute to user pool.

Also, minor updates to py scripts so that they print both the `AccessToken` and the `IdToken`. Multitenancy requires the use of the `IdToken` since it is impossible to add custom claims on the `AccessToken`. Other than custom claims, both tokens are interchangeable in our case, since `cognito:groups` is present on both tokens and the Cognito user pools APIGW Authorizer accepts Id and access tokens indistinctively.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [n/a ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
