### PR TITLE
feat: Use alias for all ES operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "axios": "^0.21.1",
     "fhir-works-on-aws-authz-rbac": "4.1.1",
     "fhir-works-on-aws-interface": "9.0.0",
-    "fhir-works-on-aws-persistence-ddb": "3.3.4",
+    "fhir-works-on-aws-persistence-ddb": "3.5.0",
     "fhir-works-on-aws-routing": "5.4.1",
-    "fhir-works-on-aws-search-es": "2.6.1",
+    "fhir-works-on-aws-search-es": "3.0.0",
     "serverless-http": "^2.3.1",
     "yargs": "^16.2.0"
   },

--- a/scripts/elasticsearch-operations.js
+++ b/scripts/elasticsearch-operations.js
@@ -110,6 +110,18 @@ const deleteIndex = async () => {
     }
 };
 
+/*
+Run the addAlias script once to add aliases for all existing indices
+
+ACCESS_KEY=<ACCESS_KEY> SECRET_KEY=<SECRET_KEY> ES_DOMAIN_ENDPOINT=<ES_DOMAIN_ENDPOINT> node elasticsearch-operations.js <region> addAlias
+
+Example:
+
+ACCESS_KEY=ABCD SECRET_KEY=XYZ ES_DOMAIN_ENDPOINT=https://search-fhir-service-dev-abcd.us-west-2.es.amazonaws.com node elasticsearch-operations.js us-west-2 addAlias
+
+If you do not know the value for ES_DOMAIN_ENDPOINT, you can follow the instruction here(https://github.com/awslabs/fhir-works-on-aws-deployment/blob/mainline/README.md#retrieving-user-variables)
+to retrieve serverless info, and find the value for ElasticSearchDomainEndpoint in the output
+ */
 const addAlias = async () => {
     // Get all indices
     const response = await es.cat.indices({ format: 'json' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5770,10 +5770,10 @@ fhir-works-on-aws-interface@^7.0.1:
   resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-7.1.0.tgz#74ec69861b9909b9d14925085a901162def8ad6c"
   integrity sha512-0Tz0ZXycp3vnKSyjnPO94rKJ7Qtz4JWLy83HpB1+qdGaAxzGaMVyW7w3vC3fkPmqOIPKxVl96pU/tXS7/Q9J8g==
 
-fhir-works-on-aws-persistence-ddb@3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-persistence-ddb/-/fhir-works-on-aws-persistence-ddb-3.3.4.tgz#c253c689be81a3ed11ef205cc1a43e578e7557c5"
-  integrity sha512-psDFHhmynCTe2msAr0meVHxflqwo1Gyqsb4oCitxfjiTZ7UOJXJ8TOZtnEdncB3MiEgZ7MVHOuKezr4MYaiJAg==
+fhir-works-on-aws-persistence-ddb@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-persistence-ddb/-/fhir-works-on-aws-persistence-ddb-3.5.0.tgz#d80837a1f6484f42b547fc880f7807c5c92ae205"
+  integrity sha512-5eHrwWocmr9aFf33lKx/POEdSPJHCTNpTTP4SdHn/ISUkwd9Wq/uTuVrrSxsK4eFrPWSTkOYEBIhsdPeaLVFHw==
   dependencies:
     "@elastic/elasticsearch" "^7.4"
     "@types/aws-lambda" "^8.10.63"
@@ -5809,10 +5809,10 @@ fhir-works-on-aws-routing@5.4.1:
     serverless-http "^2.3.1"
     uuid "^3.4.0"
 
-fhir-works-on-aws-search-es@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-search-es/-/fhir-works-on-aws-search-es-2.6.1.tgz#777efdfd215ce28220194055b5bf08f129324f49"
-  integrity sha512-fsbpSeQydC0KP3Xhbu1L3WyJQds6qvmKjBBUYjDudImrjAB+BMols8SqrI/PegEPozHabi8jfsoah/gLDOXyLA==
+fhir-works-on-aws-search-es@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-search-es/-/fhir-works-on-aws-search-es-3.0.0.tgz#fbb054d1c9a461841fa758ca1cc5a3c83fd49914"
+  integrity sha512-+eoL+PjKtwOgVmSWJs2lV0mJp2CgVPyA/X2II2PXdACrNBNI3vmabte9lxy8R6RB6Qvu4ObiEUlqtIWtweL4NA==
   dependencies:
     "@elastic/elasticsearch" "7"
     aws-elasticsearch-connector "^8.2.0"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Bump persistence and search component version to use alias for all ES operations
* Verified all integ tests passes 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
