### PR TITLE
fix: pin IG download

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Download US Core IG
         run: |
           mkdir -p implementationGuides
-          curl https://www.hl7.org/fhir/us/core/package.tgz | tar xz -C implementationGuides
+          curl http://hl7.org/fhir/us/core/STU3.1.1/package.tgz | tar xz -C implementationGuides
       - name: Compile IGs
         run: yarn run compile-igs
       - name: Install serverless

--- a/scripts/compile-igs.ts
+++ b/scripts/compile-igs.ts
@@ -49,6 +49,7 @@ async function compileIGs() {
         );
     } catch (ex) {
         console.error('Exception: ', ex.message, ex.stack);
+        process.exitCode = 1; // fail command if exception is raised
     }
 }
 

--- a/src/implementationGuides/IGCompiler.test.ts
+++ b/src/implementationGuides/IGCompiler.test.ts
@@ -170,6 +170,10 @@ describe('IGCompiler tests', () => {
                 version: '3.1.0',
                 deps: ['hl7.fhir.r4.core@4.0.1', 'us.nlm.vsac@0.3.0'],
             },
+            'us.nlm.vsac': {
+                version: '0.3.0',
+                deps: ['hl7.fhir.us.davinci-pdex-plan-net@1.0.0'],
+            },
         });
         await expect(igCompiler.compileIGs(igsDir, outputDir)).rejects.toThrow('Missing dependency us.nlm.vsac@0.3.0');
     });

--- a/src/implementationGuides/IGCompiler.test.ts
+++ b/src/implementationGuides/IGCompiler.test.ts
@@ -170,10 +170,6 @@ describe('IGCompiler tests', () => {
                 version: '3.1.0',
                 deps: ['hl7.fhir.r4.core@4.0.1', 'us.nlm.vsac@0.3.0'],
             },
-            'us.nlm.vsac': {
-                version: '0.3.0',
-                deps: ['hl7.fhir.us.davinci-pdex-plan-net@1.0.0'],
-            },
         });
         await expect(igCompiler.compileIGs(igsDir, outputDir)).rejects.toThrow('Missing dependency us.nlm.vsac@0.3.0');
     });


### PR DESCRIPTION
Description of changes:
- pin Implementation Guide to a specific version (this is for fixing our pipeline)
- Cause a process to fail if IG compilation fails (https://nodejs.dev/learn/how-to-exit-from-a-nodejs-program)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
