### PR TITLE
feat: add "enableMultiTenancy" CFN parameter 

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -16,7 +16,7 @@ custom:
   config: ${file(serverless_config.json)}
   useHapiValidator: ${opt:useHapiValidator, 'false'}
   enableMultiTenancy: ${opt:enableMultiTenancy, 'false'}
-  logLevel: ${opt:logLevel, 'debug'}
+  logLevel: ${opt:logLevel, 'error'}
   bundle:
     packager: yarn
     copyFiles: # Copy any additional files to the generated package

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -15,7 +15,8 @@ custom:
   oauthRedirect: ${opt:oauthRedirect, 'http://localhost'}
   config: ${file(serverless_config.json)}
   useHapiValidator: ${opt:useHapiValidator, 'false'}
-  logLevel: ${opt:logLevel, 'error'}
+  enableMultiTenancy: ${opt:enableMultiTenancy, 'false'}
+  logLevel: ${opt:logLevel, 'debug'}
   bundle:
     packager: yarn
     copyFiles: # Copy any additional files to the generated package
@@ -52,6 +53,7 @@ provider:
         - isUsingHapiValidator
         - Fn::ImportValue: "fhir-service-validator-lambda-${self:custom.stage}"
         - !Ref AWS::NoValue
+    ENABLE_MULTI_TENANCY: !Ref EnableMultiTenancy
     LOG_LEVEL: '${self:custom.logLevel}'
   apiKeys:
     - name: 'developer-key-${self:custom.stage}' # Full name must be known at package-time
@@ -193,6 +195,13 @@ resources:
           - 'true'
           - 'false'
         Description: whether or not to use an already deployed HAPI Validator
+      EnableMultiTenancy:
+        Type: String
+        Default: ${self:custom.enableMultiTenancy}
+        AllowedValues:
+          - 'true'
+          - 'false'
+        Description: whether or not to enable multi-tenancy
       logLevel:
         Type: String
         Default: ${self:custom.logLevel}

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,13 +25,17 @@ import HapiFhirLambdaValidator from 'fhir-works-on-aws-routing/lib/router/valida
 import RBACRules from './RBACRules';
 import { loadImplementationGuides } from './implementationGuides/loadCompiledIGs';
 
-const { IS_OFFLINE } = process.env;
+const { IS_OFFLINE, ENABLE_MULTI_TENANCY } = process.env;
+
+const enableMultiTenancy = ENABLE_MULTI_TENANCY === 'true';
 
 const fhirVersion: FhirVersion = '4.0.1';
 const baseResources = fhirVersion === '4.0.1' ? BASE_R4_RESOURCES : BASE_STU3_RESOURCES;
 const authService = IS_OFFLINE ? stubs.passThroughAuthz : new RBACHandler(RBACRules(baseResources), fhirVersion);
-const dynamoDbDataService = new DynamoDbDataService(DynamoDb);
-const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb);
+const dynamoDbDataService = new DynamoDbDataService(DynamoDb, false, { enableMultiTenancy });
+const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb, undefined, undefined, {
+    enableMultiTenancy,
+});
 
 // Configure the input validators. Validators run in the order that they appear on the array. Use an empty array to disable input validation.
 const validators: Validator[] = [];
@@ -58,6 +62,8 @@ const esSearch = new ElasticSearchService(
     DynamoDbUtil.cleanItem,
     fhirVersion,
     loadImplementationGuides('fhir-works-on-aws-search-es'),
+    undefined,
+    { enableMultiTenancy: true },
 );
 const s3DataService = new S3DataService(dynamoDbDataService, fhirVersion);
 
@@ -118,6 +124,13 @@ export const fhirConfig: FhirConfig = {
             },
         },
     },
+    multiTenancyConfig: enableMultiTenancy
+        ? {
+              enableMultiTenancy: true,
+              useTenantSpecificUrl: true,
+              tenantIdClaimPath: 'custom:tenantId',
+          }
+        : undefined,
 };
 
 export const genericResources = baseResources;


### PR DESCRIPTION
This allows to deploy fwoa with:
```sh
serverless deploy --enableMultiTenancy true
```

This deploys fwoa with multi-tenancy enabled with sensible defaults for `multiTenancyConfig`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
