### PR TITLE
feat: add "enableMultiTenancy" CFN parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "aws-sdk": "^2.785.0",
     "axios": "^0.21.1",
+    "escape-string-regexp": "^5.0.0",
     "fhir-works-on-aws-authz-smart": "2.0.0",
     "fhir-works-on-aws-interface": "9.0.0",
     "fhir-works-on-aws-persistence-ddb": "3.5.0",

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -16,6 +16,7 @@ custom:
   oAuth2ApiEndpoint: ${opt:oAuth2ApiEndpoint}
   patientPickerEndpoint: ${opt:patientPickerEndpoint}
   useHapiValidator: ${opt:useHapiValidator, 'false'}
+  enableMultiTenancy: ${opt:enableMultiTenancy, 'false'}
   logLevel: ${opt:logLevel, 'error'}
   bundle:
     packager: yarn
@@ -54,6 +55,7 @@ provider:
         - isUsingHapiValidator
         - Fn::ImportValue: "fhir-service-validator-lambda-${self:custom.stage}"
         - !Ref AWS::NoValue
+    ENABLE_MULTI_TENANCY: !Ref EnableMultiTenancy
     LOG_LEVEL: '${self:custom.logLevel}'
   apiKeys:
     - name: 'developer-key-${self:custom.stage}' # Full name must be known at package-time
@@ -188,6 +190,13 @@ resources:
           - 'true'
           - 'false'
         Description: whether or not to use an already deployed HAPI Validator
+      EnableMultiTenancy:
+        Type: String
+        Default: ${self:custom.enableMultiTenancy}
+        AllowedValues:
+          - 'true'
+          - 'false'
+        Description: whether or not to enable multi-tenancy
       logLevel:
         Type: String
         Default: ${self:custom.logLevel}

--- a/src/authZConfig.ts
+++ b/src/authZConfig.ts
@@ -23,7 +23,7 @@ export const scopeRule: ScopeRule = {
 };
 
 export function createAuthZConfig(
-    expectedAudValue: string,
+    expectedAudValue: string | RegExp,
     expectedIssValue: string,
     jwksEndpoint: string,
 ): SMARTConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,7 +52,7 @@ const apiUrl =
         : process.env.API_URL;
 
 const expectedAudValue = enableMultiTenancy
-    ? new RegExp(`^${escapeStringRegexp(apiUrl)}/tenant/([a-zA-Z0-9\\-_]{1,64})$`)
+    ? new RegExp(`^${escapeStringRegexp(apiUrl)}(/tenant/([a-zA-Z0-9\\-_]{1,64}))?$`)
     : apiUrl;
 
 const fhirVersion: FhirVersion = '4.0.1';

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,10 +22,13 @@ import {
 import { SMARTHandler } from 'fhir-works-on-aws-authz-smart';
 import JsonSchemaValidator from 'fhir-works-on-aws-routing/lib/router/validation/jsonSchemaValidator';
 import HapiFhirLambdaValidator from 'fhir-works-on-aws-routing/lib/router/validation/hapiFhirLambdaValidator';
+import escapeStringRegexp from 'escape-string-regexp';
 import { createAuthZConfig } from './authZConfig';
 import { loadImplementationGuides } from './implementationGuides/loadCompiledIGs';
 
-const { IS_OFFLINE } = process.env;
+const { IS_OFFLINE, ENABLE_MULTI_TENANCY } = process.env;
+
+const enableMultiTenancy = ENABLE_MULTI_TENANCY === 'true';
 
 // When running serverless offline, env vars are expressed as '[object Object]'
 // https://github.com/serverless/serverless/issues/7087
@@ -48,13 +51,23 @@ const apiUrl =
         ? 'https://API_URL.com'
         : process.env.API_URL;
 
+const expectedAudValue = enableMultiTenancy
+    ? new RegExp(`^${escapeStringRegexp(apiUrl)}/tenant/([a-zA-Z0-9\\-_]{1,64})$`)
+    : apiUrl;
+
 const fhirVersion: FhirVersion = '4.0.1';
 const authService = IS_OFFLINE
     ? stubs.passThroughAuthz
-    : new SMARTHandler(createAuthZConfig(apiUrl, issuerEndpoint, `${oAuth2ApiEndpoint}/keys`), apiUrl, fhirVersion);
+    : new SMARTHandler(
+          createAuthZConfig(expectedAudValue, issuerEndpoint, `${oAuth2ApiEndpoint}/keys`),
+          apiUrl,
+          fhirVersion,
+      );
 const baseResources = fhirVersion === '4.0.1' ? BASE_R4_RESOURCES : BASE_STU3_RESOURCES;
-const dynamoDbDataService = new DynamoDbDataService(DynamoDb);
-const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb);
+const dynamoDbDataService = new DynamoDbDataService(DynamoDb, false, { enableMultiTenancy });
+const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb, undefined, undefined, {
+    enableMultiTenancy,
+});
 
 // Configure the input validators. Validators run in the order that they appear on the array. Use an empty array to disable input validation.
 const validators: Validator[] = [];
@@ -137,6 +150,13 @@ export const fhirConfig: FhirConfig = {
             },
         },
     },
+    multiTenancyConfig: enableMultiTenancy
+        ? {
+              enableMultiTenancy: true,
+              useTenantSpecificUrl: true,
+              tenantIdClaimPath: 'tenantId',
+          }
+        : undefined,
 };
 
 export const genericResources = baseResources;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,6 +5183,11 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
+
 escodegen@^1.14.1, escodegen@^1.8.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"


### PR DESCRIPTION
This allows to deploy fwoa with:
```sh
serverless deploy --enableMultiTenancy true
```

This deploys fwoa with multi-tenancy enabled with sensible defaults for `multiTenancyConfig`.

Notably, we build a regex so that the `SMARTHandler` matches `aud` claims that look like `<apiUrl>` or `<apiUrl>/tenant/<tenantId>`

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-deployment/pull/381
- https://github.com/awslabs/fhir-works-on-aws-authz-smart/pull/43

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
