### PR TITLE
fix: add multi-tenant metadata route

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -94,6 +94,9 @@ functions:
       - http:
           method: GET
           path: /metadata
+      - http:
+          method: GET
+          path: /tenant/{tenantId}/metadata
     handler: src/index.default
     provisionedConcurrency: 5
     environment:


### PR DESCRIPTION
The `/metadata` path for tenant-specific urls must be allowed without authorization on the APIGW config

It would be ideal to have this path only exists when `--enableMultiTenancy true` is used but AFAIK it's not possible to use CFN conditionals in the `events` part of the serverless yaml. It doesn't pose any risk since `/tenant/{tenantId}/metadata` is a 404 anyways when multi-tenancy is not enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
