### PR TITLE
fix: allow more concurrent export jobs for multi-tenant deployments

### DIFF
--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -167,7 +167,13 @@ Resources:
         Name: glueetl
         PythonVersion: '3'
       ExecutionProperty:
-        MaxConcurrentRuns: 2
+        MaxConcurrentRuns:
+          !If
+            - isMultiTenancyEnabled
+            # Adjust this number based on the number of tenants.
+            # The default throttling on fhir-works-on-aws-persistence-ddb allows 2 concurrent export jobs per tenant
+            - 30
+            - 2
       DefaultArguments:
         '--TempDir': !Join ['', ['s3://', !Ref BulkExportResultsBucket, '/temp']]
         '--ddbTableName': '${self:custom.resourceTableName}'

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -225,6 +225,7 @@ resources:
       isDev: !Equals [!Ref Stage, 'dev']
       isNotDev: !Not [Condition: isDev]
       isUsingHapiValidator: !Equals [!Ref UseHapiValidator, 'true']
+      isMultiTenancyEnabled: !Equals [!Ref EnableMultiTenancy, 'true']
   - Resources:
       ResourceDynamoDBTableV2:
         Metadata:


### PR DESCRIPTION
Description of changes:
An higher number of Glue Job `MaxConcurrentRuns` is needed for multi-tenant deployments


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
