### PR TITLE
docs: update postman collection and docs to use Id token 

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -133,7 +133,7 @@ jobs:
         run: |
           ACCESS_TOKEN=$(aws cognito-idp initiate-auth --region us-west-2 --client-id $COGNITO_CLIENT_ID \
           --auth-flow USER_PASSWORD_AUTH --auth-parameters USERNAME=$COGNITO_USERNAME,PASSWORD=$COGNITO_PASSWORD | \
-          python -c 'import json,sys;obj=json.load(sys.stdin);print obj["AuthenticationResult"]["AccessToken"]')
+          python -c 'import json,sys;obj=json.load(sys.stdin);print obj["AuthenticationResult"]["IdToken"]')
           bundle exec rake crucible:execute_hearth_tests[$SERVICE_URL,$API_KEY,$ACCESS_TOKEN]
   custom-integration-tests:
     needs: crucible-test

--- a/postman/Fhir.postman_collection.json
+++ b/postman/Fhir.postman_collection.json
@@ -616,6 +616,138 @@
 			"protocolProfileBehavior": {}
 		},
 		{
+			"name": "Export",
+			"item": [
+				{
+					"name": "GET System Export",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{API_KEY}}"
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/$export?_outputFormat=ndjson&_since=2020-10-13T15:47:51.15Z&_type=Patient",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"$export"
+							],
+							"query": [
+								{
+									"key": "_outputFormat",
+									"value": "ndjson"
+								},
+								{
+									"key": "_since",
+									"value": "2020-10-13T15:47:51.15Z"
+								},
+								{
+									"key": "_type",
+									"value": "Patient"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET System Job Status",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{API_KEY}}"
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/$export/:jobId",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"$export",
+								":jobId"
+							],
+							"variable": [
+								{
+									"key": "jobId",
+									"value": "a40b8a52-b7d1-4d0c-8856-8a3ff0e5680a"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Export Job",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{API_KEY}}"
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/$export/:jobId",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"$export",
+								":jobId"
+							],
+							"variable": [
+								{
+									"key": "jobId",
+									"value": "1da17d30-7248-4cb5-802b-0a947344dddc"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "GET Metadata",
 			"request": {
 				"auth": {
@@ -653,7 +785,50 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Bundle",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{COGNITO_TOKEN}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "x-api-key",
+						"type": "text",
+						"value": "{{API_KEY}}"
+					},
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"resourceType\": \"Bundle\",\n  \"type\": \"transaction\",\n  \"entry\": [\n    {\n      \"fullUrl\": \"urn:uuid:8cafa46d-08b4-4ee4-b51b-803e20ae8126\",\n      \"resource\": {\n        \"resourceType\": \"Patient\",\n        \"name\": [\n          {\n            \"family\": \"Jameson\",\n            \"given\": [\n              \"Matt\"\n            ]\n          }\n        ],\n        \"gender\": \"male\"\n      },\n      \"request\": {\n        \"method\": \"POST\",\n        \"url\": \"Patient\"\n      }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Patient\",\n        \"name\": [\n          {\n            \"family\": \"Smith\",\n            \"given\": [\n              \"John\"\n            ]\n          }\n        ],\n        \"gender\": \"male\"\n      },\n      \"request\": {\n        \"method\": \"POST\",\n        \"url\": \"Patient\"\n      }\n    }\n  ]\n}\n",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{API_URL}}",
+					"host": [
+						"{{API_URL}}"
+					]
+				}
+			},
+			"response": []
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }

--- a/postman/Fhir.postman_collection.json
+++ b/postman/Fhir.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "b8585f4e-8681-476a-8c41-0ef7f5623c13",
-		"name": "FHIR Examples",
+		"_postman_id": "3a873d25-ac6d-4409-b2a0-47010659ea37",
+		"name": "FHIR",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -12,46 +12,11 @@
 					"name": "POST Binary JPEG",
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
@@ -85,6 +50,13 @@
 							],
 							"path": [
 								"Binary"
+							],
+							"query": [
+								{
+									"key": "data",
+									"value": "",
+									"disabled": true
+								}
 							]
 						}
 					},
@@ -97,46 +69,11 @@
 					},
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
@@ -144,11 +81,26 @@
 						"method": "GET",
 						"header": [
 							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
 								"key": "x-api-key",
 								"type": "text",
 								"value": "{{API_KEY}}"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{API_URL}}/Binary/:id",
 							"host": [
@@ -172,46 +124,11 @@
 					"name": "PUT Binary PDF",
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
@@ -247,6 +164,13 @@
 								"Binary",
 								":id"
 							],
+							"query": [
+								{
+									"key": "data",
+									"value": "",
+									"disabled": true
+								}
+							],
 							"variable": [
 								{
 									"key": "id",
@@ -261,46 +185,11 @@
 					"name": "DELETE Binary",
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
@@ -308,11 +197,26 @@
 						"method": "DELETE",
 						"header": [
 							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
 								"key": "x-api-key",
 								"value": "{{API_KEY}}",
 								"type": "text"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{API_URL}}/Binary/:id",
 							"host": [
@@ -334,54 +238,28 @@
 				},
 				{
 					"name": "GET Binary History Version",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
 						},
 						"method": "GET",
 						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
 							{
 								"key": "x-api-key",
 								"value": "{{API_KEY}}",
@@ -422,7 +300,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Patient",
@@ -431,46 +310,11 @@
 					"name": "POST Patient",
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
@@ -491,7 +335,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"resourceType\": \"Patient\",\n  \"text\": {\n    \"status\": \"generated\",\n    \"div\": \"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\"><p></p></div>\"\n  },\n  \"active\": true,\n  \"name\": [\n    {\n      \"family\": \"Smith\",\n      \"given\": [\"John\"]\n    }\n  ],\n  \"gender\": \"male\",\n  \"birthDate\": \"1996-09-24\",\n  \"managingOrganization\": {\n    \"reference\": \"Organization/2.16.840.1.113883.19.5\",\n    \"display\": \"Good Health Clinic\"\n  }\n}\n",
+							"raw": "{\n  \"resourceType\": \"Patient\",\n  \"text\": {\n    \"status\": \"generated\",\n    \"div\": \"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\"><p></p></div>\"\n  },\n  \"active\": true,\n  \"name\": [\n    {\n      \"family\": \"Smith\",\n      \"given\": [\"Emily\"]\n    }\n  ],\n  \"gender\": \"female\",\n  \"birthDate\": \"1995-09-24\",\n  \"managingOrganization\": {\n    \"reference\": \"Organization/2.16.840.1.113883.19.5\",\n    \"display\": \"Good Health Clinic\"\n  }\n}\n",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -514,46 +358,11 @@
 					"name": "PUT Patient",
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
@@ -574,7 +383,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"resourceType\": \"Patient\",\n  \"id\": \"905163d3-55c2-43c5-82ef-a650d71cd5aa\",\n  \"text\": {\n    \"status\": \"generated\",\n    \"div\": \"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\"><p></p></div>\"\n  },\n  \"active\": true,\n  \"name\": [\n    {\n      \"family\": \"Wang\",\n      \"given\": [\"Matt\"]\n    }\n  ],\n  \"gender\": \"male\",\n  \"birthDate\": \"1996-09-24\",\n  \"managingOrganization\": {\n    \"reference\": \"Organization/2.16.840.1.113883.19.5\",\n    \"display\": \"Good Health Clinic\"\n  }\n}\n",
+							"raw": "{\n  \"resourceType\": \"Patient\",\n  \"id\": \"20d066e0-6b73-4c0a-ab56-ef0f195f17cc\",\n  \"text\": {\n    \"status\": \"generated\",\n    \"div\": \"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\"><p></p></div>\"\n  },\n  \"active\": true,\n  \"name\": [\n    {\n      \"family\": \"Smith\",\n      \"given\": [\"Emily\"]\n    }\n  ],\n  \"gender\": \"female\",\n  \"birthDate\": \"1996-09-24\",\n  \"managingOrganization\": {\n    \"reference\": \"Organization/2.16.840.1.113883.19.5\",\n    \"display\": \"Good Health Clinic\"\n  }\n}\n",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -593,7 +402,7 @@
 							"variable": [
 								{
 									"key": "id",
-									"value": "3893c615-0962-4815-9c62-c2932e70c592"
+									"value": "20d066e0-6b73-4c0a-ab56-ef0f195f17cc"
 								}
 							]
 						}
@@ -604,52 +413,23 @@
 					"name": "GET Patient",
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
 						},
 						"method": "GET",
 						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
 							{
 								"key": "x-api-key",
 								"value": "{{API_KEY}}",
@@ -668,7 +448,53 @@
 							"variable": [
 								{
 									"key": "id",
-									"value": "8d8a2319-a404-4f0a-be8f-a002c8e96675"
+									"value": "20d066e0-6b73-4c0a-ab56-ef0f195f17cc"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE Patient",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{API_KEY}}"
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/Patient/:id",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"Patient",
+								":id"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "20d066e0-6b73-4c0a-ab56-ef0f195f17cc"
 								}
 							]
 						}
@@ -679,52 +505,23 @@
 					"name": "GET Patient History Version",
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
 						},
 						"method": "GET",
 						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
 							{
 								"key": "x-api-key",
 								"value": "{{API_KEY}}",
@@ -745,7 +542,7 @@
 							"variable": [
 								{
 									"key": "id",
-									"value": "fefbdf24-0d40-45a1-b552-a851db73f611"
+									"value": "20d066e0-6b73-4c0a-ab56-ef0f195f17cc"
 								},
 								{
 									"key": "versionId",
@@ -757,124 +554,14 @@
 					"response": []
 				},
 				{
-					"name": "DELETE Patient",
-					"request": {
-						"auth": {
-							"type": "oauth2",
-							"oauth2": [
-								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
-									"type": "string"
-								}
-							]
-						},
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "x-api-key",
-								"type": "text",
-								"value": "{{API_KEY}}"
-							}
-						],
-						"url": {
-							"raw": "{{API_URL}}/Patient/:id",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"Patient",
-								":id"
-							],
-							"variable": [
-								{
-									"key": "id",
-									"value": "f9580f1a-f357-4e3b-a9d5-d70c83cf8686"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "Search Patient",
 					"request": {
 						"auth": {
-							"type": "oauth2",
-							"oauth2": [
+							"type": "bearer",
+							"bearer": [
 								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
+									"key": "token",
+									"value": "{{COGNITO_TOKEN}}",
 									"type": "string"
 								}
 							]
@@ -888,7 +575,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{API_URL}}/Patient",
+							"raw": "{{API_URL}}/Patient?gender=female",
 							"host": [
 								"{{API_URL}}"
 							],
@@ -898,12 +585,16 @@
 							"query": [
 								{
 									"key": "gender",
-									"value": "male",
-									"disabled": true
+									"value": "female"
 								},
 								{
 									"key": "name",
 									"value": "john",
+									"disabled": true
+								},
+								{
+									"key": "managingOrganization",
+									"value": "health",
 									"disabled": true
 								},
 								{
@@ -915,269 +606,42 @@
 									"key": "_count",
 									"value": "1",
 									"disabled": true
-								},
-								{
-									"key": "_include:iterate",
-									"value": "Patient:Observation",
-									"disabled": true
 								}
 							]
 						}
 					},
 					"response": []
 				}
-			]
-		},
-		{
-			"name": "Export",
-			"item": [
-				{
-					"name": "GET System Export",
-					"request": {
-						"auth": {
-							"type": "oauth2",
-							"oauth2": [
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "accessToken",
-									"value": "",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-api-key",
-								"type": "text",
-								"value": "{{API_KEY}}"
-							}
-						],
-						"url": {
-							"raw": "{{API_URL}}/$export?_outputFormat=ndjson&_since=2020-10-13T15:47:51.15Z&_type=Patient",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"$export"
-							],
-							"query": [
-								{
-									"key": "_outputFormat",
-									"value": "ndjson"
-								},
-								{
-									"key": "_since",
-									"value": "2020-10-13T15:47:51.15Z"
-								},
-								{
-									"key": "_type",
-									"value": "Patient"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "GET System Job Status",
-					"request": {
-						"auth": {
-							"type": "oauth2",
-							"oauth2": [
-								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-api-key",
-								"type": "text",
-								"value": "{{API_KEY}}"
-							}
-						],
-						"url": {
-							"raw": "{{API_URL}}/$export/:jobId",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"$export",
-								":jobId"
-							],
-							"variable": [
-								{
-									"key": "jobId",
-									"value": "a40b8a52-b7d1-4d0c-8856-8a3ff0e5680a"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel Export Job",
-					"request": {
-						"auth": {
-							"type": "oauth2",
-							"oauth2": [
-								{
-									"key": "redirect_uri",
-									"value": "http://localhost",
-									"type": "string"
-								},
-								{
-									"key": "state",
-									"value": "abc",
-									"type": "string"
-								},
-								{
-									"key": "scope",
-									"value": "profile openid",
-									"type": "string"
-								},
-								{
-									"key": "clientId",
-									"value": "{{CLIENT_ID}}",
-									"type": "string"
-								},
-								{
-									"key": "grant_type",
-									"value": "implicit",
-									"type": "string"
-								},
-								{
-									"key": "authUrl",
-									"value": "{{AUTH_URL}}",
-									"type": "string"
-								},
-								{
-									"key": "tokenType",
-									"value": "Bearer",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
-									"type": "string"
-								}
-							]
-						},
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "x-api-key",
-								"type": "text",
-								"value": "{{API_KEY}}"
-							}
-						],
-						"url": {
-							"raw": "{{API_URL}}/$export/:jobId",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"$export",
-								":jobId"
-							],
-							"variable": [
-								{
-									"key": "jobId",
-									"value": "1da17d30-7248-4cb5-802b-0a947344dddc"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "GET Metadata",
 			"request": {
 				"auth": {
-					"type": "noauth"
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{COGNITO_TOKEN}}",
+							"type": "string"
+						}
+					]
 				},
 				"method": "GET",
-				"header": [],
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{API_KEY}}",
+						"type": "text"
+					}
+				],
 				"url": {
 					"raw": "{{API_URL}}/metadata",
 					"host": [
@@ -1189,85 +653,7 @@
 				}
 			},
 			"response": []
-		},
-		{
-			"name": "Bundle",
-			"request": {
-				"auth": {
-					"type": "oauth2",
-					"oauth2": [
-						{
-							"key": "redirect_uri",
-							"value": "http://localhost",
-							"type": "string"
-						},
-						{
-							"key": "state",
-							"value": "abc",
-							"type": "string"
-						},
-						{
-							"key": "scope",
-							"value": "profile openid",
-							"type": "string"
-						},
-						{
-							"key": "clientId",
-							"value": "{{CLIENT_ID}}",
-							"type": "string"
-						},
-						{
-							"key": "grant_type",
-							"value": "implicit",
-							"type": "string"
-						},
-						{
-							"key": "authUrl",
-							"value": "{{AUTH_URL}}",
-							"type": "string"
-						},
-						{
-							"key": "tokenType",
-							"value": "Bearer",
-							"type": "string"
-						},
-						{
-							"key": "addTokenTo",
-							"value": "header",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "x-api-key",
-						"type": "text",
-						"value": "{{API_KEY}}"
-					},
-					{
-						"key": "Content-Type",
-						"type": "text",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"resourceType\": \"Bundle\",\n  \"type\": \"transaction\",\n  \"entry\": [\n    {\n      \"fullUrl\": \"urn:uuid:8cafa46d-08b4-4ee4-b51b-803e20ae8126\",\n      \"resource\": {\n        \"resourceType\": \"Patient\",\n        \"name\": [\n          {\n            \"family\": \"Jameson\",\n            \"given\": [\n              \"Matt\"\n            ]\n          }\n        ],\n        \"gender\": \"male\"\n      },\n      \"request\": {\n        \"method\": \"POST\",\n        \"url\": \"Patient\"\n      }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Patient\",\n        \"name\": [\n          {\n            \"family\": \"Smith\",\n            \"given\": [\n              \"John\"\n            ]\n          }\n        ],\n        \"gender\": \"male\"\n      },\n      \"request\": {\n        \"method\": \"POST\",\n        \"url\": \"Patient\"\n      }\n    }\n  ]\n}\n",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{API_URL}}",
-					"host": [
-						"{{API_URL}}"
-					]
-				}
-			},
-			"response": []
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }

--- a/postman/Fhir_Dev_Env.json
+++ b/postman/Fhir_Dev_Env.json
@@ -15,14 +15,8 @@
     },
     {
       "enabled": true,
-      "key": "AUTH_URL",
-      "value": "<AUTH_URL>",
-      "type": "text"
-    },
-    {
-      "enabled": true,
-      "key": "CLIENT_ID",
-      "value": "CLIENT_ID",
+      "key": "COGNITO_TOKEN",
+      "value": "<COGNITO_AUTH_TOKEN>",
       "type": "text"
     }
   ],

--- a/postman/Fhir_Local_Env.json
+++ b/postman/Fhir_Local_Env.json
@@ -12,18 +12,6 @@
       "key": "API_KEY",
       "value": "<API_KEY_WHEN_RUNNING_SLS_OFFLINE>",
       "type": "text"
-    },
-    {
-      "enabled": true,
-      "key": "AUTH_URL",
-      "value": "<AUTH_URL>",
-      "type": "text"
-    },
-    {
-      "enabled": true,
-      "key": "CLIENT_ID",
-      "value": "CLIENT_ID",
-      "type": "text"
     }
   ],
   "_postman_variable_scope": "environment",

--- a/postman/Fhir_Prod_Env.json
+++ b/postman/Fhir_Prod_Env.json
@@ -15,14 +15,8 @@
     },
     {
       "enabled": true,
-      "key": "AUTH_URL",
-      "value": "<AUTH_URL>",
-      "type": "text"
-    },
-    {
-      "enabled": true,
-      "key": "CLIENT_ID",
-      "value": "CLIENT_ID",
+      "key": "COGNITO_TOKEN",
+      "value": "<COGNITO_AUTH_TOKEN>",
       "type": "text"
     }
   ],

--- a/scripts/init-auth.py
+++ b/scripts/init-auth.py
@@ -22,4 +22,5 @@ response = client.initiate_auth(
     ClientId=sys.argv[1]
 )
 
-print(json.dumps(response['AuthenticationResult'], indent=2))
+id_token = response['AuthenticationResult']['IdToken']
+print(id_token)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -315,7 +315,7 @@ cd ${PACKAGE_ROOT}/scripts
 echo "Setting up AWS Cognito with default user credentials to support authentication in the future..."
 echo "This will output a token that you can use to access the FHIR API."
 echo "(You can generate a new token at any time after setup using the included init-auth.py script)"
-echo -e "\nACCESS TOKEN:"
+echo -e "\nID TOKEN:"
 echo -e "\n***\n"
 python3 provision-user.py "$UserPoolId" "$UserPoolAppClientId" "$region" >/dev/null 2>&1 ||
     echo -e "Warning: Cognito has already been initialized.\nIf you need to generate a new token, please use the init-auth.py script.\nContinuing..."

--- a/scripts/provision-user.py
+++ b/scripts/provision-user.py
@@ -82,4 +82,5 @@ response = client.initiate_auth(
     ClientId=sys.argv[2]
 )
 
-print(json.dumps(response['AuthenticationResult'], indent=2))
+id_token = response['AuthenticationResult']['IdToken']
+print(id_token)

--- a/scripts/win_install.ps1
+++ b/scripts/win_install.ps1
@@ -293,7 +293,7 @@ Set-Location $rootDir\scripts
 Write-Host "Setting up AWS Cognito with default user credentials to support authentication in the future..."
 Write-Host "This will output a token that you can use to access the FHIR API."
 Write-Host "(You can generate a new token at any time after setup using the included init-auth.py script)"
-Write-Host "`nACCESS TOKEN:"
+Write-Host "`nID TOKEN:"
 Write-Host "`n***`n"
 
 #CHECK


### PR DESCRIPTION
Description of changes:

Multi-tenancy requires the use of the Cognito `IdToken` instead of the `AccessToken` since only the `IdToken` can have custom claims to store the `tenantId`.

We updated the default single-tenant deployment to also use the `IdToken` since maintaining support for both token types adds complexity.


The postman collection was reverted to using the `COGNITO_AUTH_TOKEN` (which means running a script and copying the token into postman). It was possible to signin to Cognito from postman and get an access token, but postman makes it impossible to use the Id Token that way. See: https://github.com/postmanlabs/postman-app-support/issues/492, https://github.com/postmanlabs/postman-app-support/issues/8231

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
