### PR TITLE
chore: add boundary to serverless auto generated role

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -578,8 +578,38 @@ resources:
                 reason: 'KMS CMK not defined here'
         Type: AWS::SQS::Queue
         Properties:
-          MessageRetentionPeriod: 1209600 # 14 days in seconds 
+          MessageRetentionPeriod: 1209600 # 14 days in seconds
+
+      # Create a permissions boundary for role Serverless creates to manage Cloudwatch access
+      # The default role has permission to create any role and attach any policy. Here we are restricting
+      # the role to only create a specific role and attach only Cloudwatch publishing managed policy
+      ServerlessLogsBoundary:
+        Type: AWS::IAM::ManagedPolicy
+        Properties:
+          Description: Allows serverless to manage CloudWatch publishing
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - apigateway:GET
+                  - apigateway:PATCH
+                Resource: !Sub 'arn:${AWS::Partition}:apigateway:${AWS::Region}::/account'
+              - Effect: Allow
+                Action:
+                  - iam:CreateRole
+                  - iam:AttachRolePolicy
+                  - iam:ListAttachedRolePolicies
+                  - iam:PassRole
+                Resource: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/serverlessApiGatewayCloudWatchRole'
+                Condition:
+                  ArnEqualsIfExists:
+                    iam:PolicyARN: 'arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs'
   - extensions:
+      # Add custom permission boundary to role serverless uses for creating Cloudwatch publishing role
+      IamRoleCustomResourcesLambdaExecution:
+        Properties:
+          PermissionsBoundary: !Ref ServerlessLogsBoundary
       DdbToEsEventSourceMappingDynamodbResourceDynamoDBTableV2:
         Properties:
           DestinationConfig:


### PR DESCRIPTION
Essentially the same as: https://github.com/awslabs/service-workbench-on-aws/pull/402

The `IamRoleCustomResourcesLambdaExecution` role generated by the Serverless framework is a bit too open (notably it could escalate permissions due to `iam:AttachRolePolicy *`). We are adding a permission boundary to restrict its permissions

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [n/a] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
