### PR TITLE
fix: Add server side encryption to the AuditLogsBucket

### DIFF
--- a/auditLogMover/serverless.yaml
+++ b/auditLogMover/serverless.yaml
@@ -82,6 +82,11 @@ resources:
   Resources:
     AuditLogsBucket:
       Type: AWS::S3::Bucket
+      Properties:
+        BucketEncryption:
+            ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
     AuditLogsBucketPolicy:
       Type: AWS::S3::BucketPolicy
       Properties:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Add s3 Server Side Encryption via AES256 to the AuditLogsBucket. Currently the bucket is unencrypted but Cloudwatch logs supports exports to S3 SSE via AES256. This helps prevent the possibility of sensitive information in API Gateway logs being archived unencrypted.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
