### PR TITLE
chore: restrict Kibana user creation to be admin only

### DIFF
--- a/cloudformation/elasticsearch.yaml
+++ b/cloudformation/elasticsearch.yaml
@@ -8,6 +8,8 @@ Resources:
     Type: AWS::Cognito::UserPool
     Condition: isDev
     Properties:
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: true
       AutoVerifiedAttributes:
         - email
       UserPoolName: !Sub '${AWS::StackName}-Kibana'
@@ -86,8 +88,8 @@ Resources:
     Metadata:
       cfn_nag:
         rules_to_suppress:
-            - id: W90
-              reason: 'We do not want a VPC for ElasticSearch. We are controlling access to ES using IAM roles'
+          - id: W90
+            reason: 'We do not want a VPC for ElasticSearch. We are controlling access to ES using IAM roles'
     Properties:
       EBSOptions: # Assuming ~100GB storage requirement for PROD; min storage requirement is ~290GB https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/sizing-domains.html
         EBSEnabled: true


### PR DESCRIPTION
This change restricts Kibana user creation to JUST admins instead of self-sign ups

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.