### PR TITLE
feat: update ES to 7.10 and utilize Graviton instances for EC2 clusters

### DIFF
--- a/cloudformation/elasticsearch.yaml
+++ b/cloudformation/elasticsearch.yaml
@@ -90,19 +90,21 @@ Resources:
         rules_to_suppress:
           - id: W90
             reason: 'We do not want a VPC for ElasticSearch. We are controlling access to ES using IAM roles'
+    UpdatePolicy:
+      EnableVersionUpgrade: true
     Properties:
       EBSOptions: # Assuming ~100GB storage requirement for PROD; min storage requirement is ~290GB https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/sizing-domains.html
         EBSEnabled: true
         VolumeType: gp2
         VolumeSize: !If [isDev, 10, 73]
       ElasticsearchClusterConfig:
-        InstanceType: !If [isDev, t3.medium.elasticsearch, m5.large.elasticsearch]
+        InstanceType: !If [isDev, c6g.large.elasticsearch, m6g.large.elasticsearch]
         InstanceCount: !If [isDev, 1, 4]
         DedicatedMasterEnabled: !If [isDev, false, true]
         DedicatedMasterCount: !If [isDev, !Ref AWS::NoValue, 3]
-        DedicatedMasterType: !If [isDev, !Ref AWS::NoValue, c5.large.elasticsearch]
+        DedicatedMasterType: !If [isDev, !Ref AWS::NoValue, c6g.large.elasticsearch]
         ZoneAwarenessEnabled: !If [isDev, false, true]
-      ElasticsearchVersion: '7.4'
+      ElasticsearchVersion: '7.10'
       EncryptionAtRestOptions:
         Enabled: true
         KmsKeyId: !Ref ElasticSearchKMSKey


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Updated ES version from 7.4 to 7.10, and updated instances from t3, m5, and c5 to c6g and m6g. I chose these instances as they had similar [hardware specifications](https://aws.amazon.com/blogs/aws/new-graviton2-instance-types-c6g-r6g-and-their-d-variant/) to the previous instances, and m6g was the most general purpose solution.
I tested these changes by deploying after updating the CloudFormation template to my AWS account, and ensuring that all functions dependent on ES such as the search component were still functioning as expected.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
