### PR TITLE
fix: group export with group created before _since

### DIFF
--- a/integration-tests/bulkExportTestHelper.ts
+++ b/integration-tests/bulkExportTestHelper.ts
@@ -142,6 +142,13 @@ export default class BulkExportTestHelper {
         }
     }
 
+    async updateResource(resource: any) {
+        const resourceToUpdate = cloneDeep(resource);
+        delete resourceToUpdate.meta;
+        const response = await this.fhirUserAxios.put(`/${resource.resourceType}/${resource.id}`, resourceToUpdate);
+        return response.data;
+    }
+
     // This method does not require FHIR user credentials in the header because the url is an S3 presigned URL
     static async downloadFile(url: string): Promise<any[]> {
         try {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Before this fix, if a group was last updated before the _since timestamp in group export, the group will be removed form the dataframe before we reach the group filter step. This would cause the script to error out for index out of bound. 
* In this fix, the order of _since timestamp filter and group filter is shifted so group export will succeed with the members updated after the _since timestamp. 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
