### PR TITLE
chore: update nodejs runtime version to 14

### DIFF
--- a/.github/workflows/build-and-validate.yaml
+++ b/.github/workflows/build-and-validate.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         run: |
           cd auditLogMover

--- a/.github/workflows/cfn-analysis.yml
+++ b/.github/workflows/cfn-analysis.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - name: Install npm dependencies
         run: yarn install
       - name: Install serverless

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
@@ -69,7 +69,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
@@ -180,7 +180,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         run: |
           yarn install

--- a/auditLogMover/serverless.yaml
+++ b/auditLogMover/serverless.yaml
@@ -13,7 +13,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   stage: dev
   region: us-west-2
   memorySize: 256

--- a/package.json
+++ b/package.json
@@ -115,6 +115,6 @@
     "url": "git://github.com/awslabs/fhir-works-on-aws-deployment.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   }
 }

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -36,7 +36,7 @@ provider:
   name: aws
   region: us-west-2
   stage: dev
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   memorySize: 512
   logRetentionInDays: 3653 # 10 years
   stackTags:
@@ -113,7 +113,7 @@ functions:
 
   ddbToEs:
     timeout: 300
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     description: 'Write DDB changes from `resource` table to ElasticSearch service'
     role: DdbToEsLambdaRole
     handler: ddbToEsLambda/index.handler
@@ -130,7 +130,7 @@ functions:
   startExportJob:
     timeout: 30
     memorySize: 192
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     description: 'Start the Glue job for bulk export'
     role: GlueJobRelatedLambdaRole
     handler: bulkExport/index.startExportJobHandler
@@ -140,7 +140,7 @@ functions:
   stopExportJob:
     timeout: 30
     memorySize: 192
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     description: 'Stop the Glue job for bulk export'
     role: GlueJobRelatedLambdaRole
     handler: bulkExport/index.stopExportJobHandler
@@ -150,7 +150,7 @@ functions:
   getJobStatus:
     timeout: 30
     memorySize: 192
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     description: 'Get the status of a Glue job run for bulk export'
     role: GlueJobRelatedLambdaRole
     handler: bulkExport/index.getJobStatusHandler
@@ -160,7 +160,7 @@ functions:
   updateStatus:
     timeout: 30
     memorySize: 192
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     description: 'Update the status of a bulk export job'
     role: UpdateStatusLambdaRole
     handler: bulkExport/index.updateStatusStatusHandler
@@ -168,7 +168,7 @@ functions:
   uploadGlueScripts:
     timeout: 30
     memorySize: 192
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     description: 'Upload glue scripts to s3'
     role: UploadGlueScriptsLambdaRole
     handler: bulkExport/uploadGlueScriptsToS3.handler


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Updated `serverless.yaml` to use node js run time `nodejs14.x` instead. Deployed to AWS Account with no downtime or alarms in around 3-5 minutes.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
