### PR TITLE
feat: enable KMS decryption for token introspection secrets

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -19,6 +19,7 @@ custom:
   enableMultiTenancy: ${opt:enableMultiTenancy, 'false'}
   logLevel: ${opt:logLevel, 'error'}
   enableESHardDelete: ${opt:enableESHardDelete, 'false'}
+  enableTokenIntrospection: ${opt:enableTokenIntrospection, 'false'}
   patientCompartmentFileV3: 'patientCompartmentSearchParams.3.0.2.json'
   patientCompartmentFileV4: 'patientCompartmentSearchParams.4.0.1.json'
   bundle:
@@ -63,6 +64,7 @@ provider:
         - Fn::ImportValue: "fhir-service-validator-lambda-${self:custom.stage}"
         - !Ref AWS::NoValue
     ENABLE_MULTI_TENANCY: !Ref EnableMultiTenancy
+    ENABLE_TOKEN_INTROSPECTION: !Ref EnableTokenIntrospection
     LOG_LEVEL: '${self:custom.logLevel}'
   apiKeys:
     - name: 'developer-key-${self:custom.stage}' # Full name must be known at package-time
@@ -214,6 +216,13 @@ resources:
           - 'true'
           - 'false'
         Description: whether or not to enable multi-tenancy
+      EnableTokenIntrospection:
+        Type: String
+        Default: ${self:custom.enableTokenIntrospection}
+        AllowedValues:
+          - 'true'
+          - 'false'
+        Description: whether or not token introspection is enabled
       logLevel:
         Type: String
         Default: ${self:custom.logLevel}
@@ -227,6 +236,7 @@ resources:
       isNotDev: !Not [Condition: isDev]
       isUsingHapiValidator: !Equals [!Ref UseHapiValidator, 'true']
       isMultiTenancyEnabled: !Equals [!Ref EnableMultiTenancy, 'true']
+      isTokenIntrospectionEnabled: !Equals [!Ref EnableTokenIntrospection, 'true']
   - Resources:
       ResourceDynamoDBTableV2:
         Metadata:

--- a/src/authZConfig.ts
+++ b/src/authZConfig.ts
@@ -2,7 +2,10 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
-import { SMARTConfig, ScopeRule } from 'fhir-works-on-aws-authz-smart';
+import { SMARTConfig, ScopeRule, IntrospectionOptions } from 'fhir-works-on-aws-authz-smart';
+import { kmsDecrypt } from './configUtils';
+
+const enableTokenIntrospection = process.env.ENABLE_TOKEN_INTROSPECTION === 'true';
 
 // if they have a system level operation then you need * as resourceType
 
@@ -22,11 +25,23 @@ export const scopeRule: ScopeRule = {
     },
 };
 
-export function createAuthZConfig(
+export async function getIntrospectionOptions(): Promise<IntrospectionOptions | undefined> {
+    let introspectionOptions;
+    if (enableTokenIntrospection) {
+        introspectionOptions = {
+            clientId: (await kmsDecrypt(process.env.INTROSPECTION_CLIENT_ID)) ?? '',
+            clientSecret: (await kmsDecrypt(process.env.INTROSPECTION_CLIENT_SECRET)) ?? '',
+            introspectUrl: `${process.env.INTROSPECTION_ENDPOINT}/oauth2/introspect`,
+        };
+    }
+    return introspectionOptions;
+}
+
+export async function createAuthZConfig(
     expectedAudValue: string | RegExp,
     expectedIssValue: string,
     jwksEndpoint: string,
-): SMARTConfig {
+): Promise<SMARTConfig> {
     return {
         version: 1.0,
         scopeKey: 'scp',
@@ -36,5 +51,6 @@ export function createAuthZConfig(
         fhirUserClaimPath: 'fhirUser',
         launchContextPathPrefix: 'launch_response_',
         jwksEndpoint,
+        tokenIntrospection: await getIntrospectionOptions(),
     };
 }

--- a/src/configUtils.ts
+++ b/src/configUtils.ts
@@ -1,0 +1,32 @@
+import AWS from 'aws-sdk';
+import { makeLogger } from 'fhir-works-on-aws-interface';
+
+const componentLogger = makeLogger({
+    component: 'search',
+});
+
+export default function getComponentLogger(): any {
+    return componentLogger;
+}
+
+const logger = getComponentLogger();
+const kms = new AWS.KMS();
+
+export async function kmsDecrypt(cipherText: string | undefined) {
+    let decryptedText;
+    if (cipherText) {
+        try {
+            const request = {
+                CiphertextBlob: Buffer.from(cipherText, 'base64'),
+            };
+            const data = await kms.decrypt(request).promise();
+            decryptedText = data.Plaintext?.toString('ascii');
+        } catch (err) {
+            logger.error('Decrypt error: ', err);
+            throw err;
+        }
+    } else {
+        logger.warn('Cannot perform decryption because cipherText is undefined.');
+    }
+    return decryptedText;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,18 @@
 
 import serverless from 'serverless-http';
 import { generateServerlessRouter } from 'fhir-works-on-aws-routing';
-import { fhirConfig, genericResources } from './config';
+import { getFhirConfig, genericResources } from './config';
 
-const serverlessHandler = serverless(generateServerlessRouter(fhirConfig, genericResources), {
-    request(request: any, event: any) {
-        request.user = event.user;
-    },
-});
+async function asyncServerless() {
+    return serverless(generateServerlessRouter(await getFhirConfig(), genericResources), {
+        request(request: any, event: any) {
+            request.user = event.user;
+        },
+    });
+}
+
+const serverlessHandler = asyncServerless();
 
 export default async (event: any = {}, context: any = {}): Promise<any> => {
-    return serverlessHandler(event, context);
+    return (await serverlessHandler)(event, context);
 };


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/fhir-works-on-aws-deployment/issues/432

Description of changes:
made creation of fhirConfig async so I could use kms.decrypt for kms encrypted client_id & secret

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
