### PR TITLE
fix: give Glue IAM Role access to KMS keys

### DIFF
--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -163,8 +163,34 @@ Resources:
                 Action:
                   - s3:GetObject
                 Resource: !Join ['', ['arn:aws:s3:::', !Ref GlueScriptsBucket, '/*']]
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey
+                  - kms:Encrypt
+                Resource:
+                  - !GetAtt S3KMSKey.Arn
+        - PolicyName: logAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:AssociateKmsKey
+                Resource:
+                  - arn:aws:logs:*:*:/aws-glue/*
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey
+                  - kms:Encrypt
+                Resource:
+                  - !GetAtt LogKMSKey.Arn
 
-  GlueJobSecurityConfiguration:
+  GlueJobSecurityConfig:
     Type: AWS::Glue::SecurityConfiguration
     Properties:
       EncryptionConfiguration:
@@ -172,7 +198,7 @@ Resources:
           KmsKeyArn: !GetAtt LogKMSKey.Arn
           CloudWatchEncryptionMode: SSE-KMS
         S3Encryptions:
-          - KmsKeyArn: !GetAtt LogKMSKey.Arn
+          - KmsKeyArn: !GetAtt S3KMSKey.Arn
             S3EncryptionMode: SSE-KMS
         JobBookmarksEncryption:
           KmsKeyArn: !GetAtt LogKMSKey.Arn
@@ -189,7 +215,7 @@ Resources:
       GlueVersion: '2.0'
       WorkerType: !Ref ExportGlueWorkerType
       NumberOfWorkers: !Ref ExportGlueNumberWorkers
-      SecurityConfiguration: !Ref GlueJobSecurityConfiguration
+      SecurityConfiguration: !Ref GlueJobSecurityConfig
       Command:
         ScriptLocation: !Join ['', ['s3://', !Ref GlueScriptsBucket, '/export-script.py']]
         Name: glueetl


### PR DESCRIPTION
Description of changes:
To use the Glue Security Configuration, the Glue job must also have access to the KMS keys

references
- https://docs.amazonaws.cn/en_us/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
- https://github.com/awsdocs/aws-glue-developer-guide/blob/master/doc_source/create-service-policy.md
- https://docs.aws.amazon.com/glue/latest/dg/console-security-configurations.html

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
