### PR TITLE
chore: rename GlueJobSecurityConfig

### DIFF
--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -203,7 +203,7 @@ Resources:
         JobBookmarksEncryption:
           KmsKeyArn: !GetAtt LogKMSKey.Arn
           JobBookmarksEncryptionMode: CSE-KMS
-      Name: 'bulk-export-security-config'
+      Name: 'export-security-config'
     DependsOn:
       - LogKMSKey
 


### PR DESCRIPTION
Description of changes:
- GlueJobSecurityConfig was previously deployed and does not support Cloudformation 'update' so we must create a new one and a new one is defined by a different name.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
