### PR TITLE
fix: handle when failures happen in bulk export

### DIFF
--- a/bulkExport/state-machine-definition.yaml
+++ b/bulkExport/state-machine-definition.yaml
@@ -5,51 +5,52 @@
 
 id: BulkExportStateMachine
 definition:
-  Comment: "State machine that executes a FHIR bulk export job"
+  Comment: 'State machine that executes a FHIR bulk export job'
   StartAt: parallelHelper
   States:
     catchAllUpdateStatusToFailed:
       Type: Task
       Resource: !GetAtt updateStatus.Arn
-      Parameters: {"jobId.$":"$.jobId", "status": "failed"}
+      Parameters: { 'globalParams.$': '$', 'status': 'failed' }
       Retry:
-        - ErrorEquals: [ "States.ALL" ]
+        - ErrorEquals: ['States.ALL']
       End: true
     parallelHelper:
       Type: Parallel
       End: true
       Catch:
-        - ErrorEquals: [ "States.ALL" ]
+        - ErrorEquals: ['States.ALL']
           Next: catchAllUpdateStatusToFailed
+          ResultPath: '$.error'
       Branches:
         - StartAt: startExportJob
           States:
             updateStatusToFailed:
               Type: Task
               Resource: !GetAtt updateStatus.Arn
-              Parameters: {"globalParams.$":"$", "status": "failed"}
+              Parameters: { 'globalParams.$': '$', 'status': 'failed' }
               Retry:
-                - ErrorEquals: [ "States.ALL" ]
+                - ErrorEquals: ['States.ALL']
               End: true
             updateStatusToCanceled:
               Type: Task
               Resource: !GetAtt updateStatus.Arn
-              Parameters: {"globalParams.$":"$", "status": "canceled"}
+              Parameters: { 'globalParams.$': '$', 'status': 'canceled' }
               Retry:
-                - ErrorEquals: [ "States.ALL" ]
+                - ErrorEquals: ['States.ALL']
               End: true
             updateStatusToCompleted:
               Type: Task
               Resource: !GetAtt updateStatus.Arn
-              Parameters: {"globalParams.$":"$", "status": "completed"}
+              Parameters: { 'globalParams.$': '$', 'status': 'completed' }
               Retry:
-                - ErrorEquals: [ "States.ALL" ]
+                - ErrorEquals: ['States.ALL']
               End: true
             startExportJob:
               Type: Task
               Resource: !GetAtt startExportJob.Arn
               Retry:
-                - ErrorEquals: [ "States.ALL" ]
+                - ErrorEquals: ['States.ALL']
               Next: waitForExportJob
             waitForExportJob:
               Type: Wait
@@ -59,37 +60,37 @@ definition:
               Type: Task
               Resource: !GetAtt getJobStatus.Arn
               Retry:
-                - ErrorEquals: [ "States.ALL" ]
+                - ErrorEquals: ['States.ALL']
               Next: choiceOnJobStatus
             choiceOnJobStatus:
               Type: Choice
               Choices:
-                - Variable: "$.executionParameters.isCanceled"
+                - Variable: '$.executionParameters.isCanceled'
                   BooleanEquals: true
                   Next: stopExportJob
-                - Variable: "$.executionParameters.glueJobRunStatus"
+                - Variable: '$.executionParameters.glueJobRunStatus'
                   StringEquals: 'SUCCEEDED'
                   Next: updateStatusToCompleted
                 - Or:
-                  - Variable: "$.executionParameters.glueJobRunStatus"
-                    StringEquals: 'STARTING'
-                  - Variable: "$.executionParameters.glueJobRunStatus"
-                    StringEquals: 'RUNNING'
+                    - Variable: '$.executionParameters.glueJobRunStatus'
+                      StringEquals: 'STARTING'
+                    - Variable: '$.executionParameters.glueJobRunStatus'
+                      StringEquals: 'RUNNING'
                   Next: waitForExportJob
                 - Or:
-                  - Variable: "$.executionParameters.glueJobRunStatus"
-                    StringEquals: 'FAILED'
-                  - Variable: "$.executionParameters.glueJobRunStatus"
-                    StringEquals: 'TIMEOUT'
-                  - Variable: "$.executionParameters.glueJobRunStatus"
-                    # STOPPING and STOPPED can only occur here if the job was forcefully stopped with a Glue API call from outside the FHIR server, so we treat it as failure
-                    StringEquals: 'STOPPING'
-                  - Variable: "$.executionParameters.glueJobRunStatus"
-                    StringEquals: 'STOPPED'
+                    - Variable: '$.executionParameters.glueJobRunStatus'
+                      StringEquals: 'FAILED'
+                    - Variable: '$.executionParameters.glueJobRunStatus'
+                      StringEquals: 'TIMEOUT'
+                    - Variable: '$.executionParameters.glueJobRunStatus'
+                      # STOPPING and STOPPED can only occur here if the job was forcefully stopped with a Glue API call from outside the FHIR server, so we treat it as failure
+                      StringEquals: 'STOPPING'
+                    - Variable: '$.executionParameters.glueJobRunStatus'
+                      StringEquals: 'STOPPED'
                   Next: updateStatusToFailed
             stopExportJob:
               Type: Task
               Resource: !GetAtt stopExportJob.Arn
               Retry:
-                - ErrorEquals: [ "States.ALL" ]
+                - ErrorEquals: ['States.ALL']
               Next: updateStatusToCanceled


### PR DESCRIPTION
Description of changes:
- Previously `catchAllUpdateStatusToFailed` step in our step function did not pass the required `jobId` to update the DDB table. This resulted in the all future exports being broken due to the system believing the export is currently running.
- **To fix:** we need to put the error in a different json path & have this step function have the same input as the other status update ones.
  -  https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultpath.html#input-output-resultpath-catch
- Most of the file is yaml linting to match our other CFN files. I will highlight the 2 material changes

Testing:
- I tested this by focusing the `getJobStatus` step to throw an error and ensuring that the `catchAllUpdateStatusToFailed` step ran correctly and updated the DDB

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
