### PR TITLE
fix: Add SNS encryption for FhirWorksAlarm

### DIFF
--- a/cloudformation/alarms.yaml
+++ b/cloudformation/alarms.yaml
@@ -579,6 +579,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties: 
       DisplayName: !Join ['-', [FhirSolution, !Ref Stage, cloudwatch, alarm, topic]]
+      KmsMasterKeyId: !Ref SnsKMSKey
   FhirWorksAlarmSNSTopicPolicy:
     Type: AWS::SNS::TopicPolicy
     DependsOn: FhirWorksAlarmSNSTopic

--- a/cloudformation/kms.yaml
+++ b/cloudformation/kms.yaml
@@ -113,10 +113,10 @@ Resources:
               AWS: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
             Action: 'kms:*'
             Resource: '*'
-          - Sid: 'Allow SNS to use this Key Policy'
+          - Sid: 'Allow Cloudwatch to use this Key Policy'
             Effect: Allow
             Principal:
-              Service: sns.amazonaws.com
+              Service: cloudwatch.amazonaws.com
             Action:
               - kms:Encrypt
               - kms:Decrypt

--- a/cloudformation/kms.yaml
+++ b/cloudformation/kms.yaml
@@ -122,6 +122,3 @@ Resources:
               - kms:Decrypt
               - kms:GenerateDataKey*
             Resource: '*'
-
-
-

--- a/cloudformation/kms.yaml
+++ b/cloudformation/kms.yaml
@@ -94,4 +94,34 @@ Resources:
             Condition:
               ArnLike:
                 kms:EncryptionContext:aws:logs:arn: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+  SnsAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Join ['-', [alias/snsKey, !Ref Stage]]
+      TargetKeyId: !Ref SnsKMSKey
+  SnsKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      Description: 'KMS CMK for SNS'
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: 'Enable IAM Root Permissions'
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+          - Sid: 'Allow SNS to use this Key Policy'
+            Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+            Resource: '*'
+
+
 

--- a/cloudformation/kms.yaml
+++ b/cloudformation/kms.yaml
@@ -122,3 +122,12 @@ Resources:
               - kms:Decrypt
               - kms:GenerateDataKey*
             Resource: '*'
+          - Sid: 'Allow SNS to use this Key Policy'
+            Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+            Resource: '*'


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Add SNS encryption for FhirWorksAlarm. As best practices Amazon recommends encrypting SNS topics. 


References
https://aws.amazon.com/blogs/compute/encrypting-messages-published-to-amazon-sns-with-aws-kms/
https://stackoverflow.com/a/58849754
https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
