### PR TITLE
feat: allow async creation of FhirConfig

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -72,7 +72,7 @@ const OAuthUrl =
         ? 'https://OAUTH2.com'
         : process.env.OAUTH2_DOMAIN_ENDPOINT;
 
-export const fhirConfig: FhirConfig = {
+export const getFhirConfig = async (): Promise<FhirConfig> => ({
     configVersion: 1.0,
     productInfo: {
         orgName: 'Organization Name',
@@ -131,6 +131,6 @@ export const fhirConfig: FhirConfig = {
               tenantIdClaimPath: 'custom:tenantId',
           }
         : undefined,
-};
+});
 
 export const genericResources = baseResources;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,30 @@
 
 import serverless from 'serverless-http';
 import { generateServerlessRouter } from 'fhir-works-on-aws-routing';
-import { fhirConfig, genericResources } from './config';
+import { getFhirConfig, genericResources } from './config';
 
-const serverlessHandler = serverless(generateServerlessRouter(fhirConfig, genericResources), {
-    request(request: any, event: any) {
-        request.user = event.user;
-    },
-});
+const ensureAsyncInit = async (initPromise: Promise<any>): Promise<void> => {
+    try {
+        await initPromise;
+    } catch (e) {
+        console.error('Async initialization failed', e);
+        // Explicitly exit the process so that next invocation re-runs the init code.
+        // This prevents Lambda containers from caching a rejected init promise
+        process.exit(1);
+    }
+};
+
+async function asyncServerless() {
+    return serverless(generateServerlessRouter(await getFhirConfig(), genericResources), {
+        request(request: any, event: any) {
+            request.user = event.user;
+        },
+    });
+}
+
+const serverlessHandler: Promise<any> = asyncServerless();
 
 export default async (event: any = {}, context: any = {}): Promise<any> => {
-    return serverlessHandler(event, context);
+    await ensureAsyncInit(serverlessHandler);
+    return (await serverlessHandler)(event, context);
 };


### PR DESCRIPTION
This allows customers to make async calls when building the FhirConfig. This can be useful for example to fetch configuration from AWS Systems Manager Parameter Store.

There are no functional changes.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [n/a] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
