### PR TITLE
feat: allow async creation of FhirConfig

### DIFF
--- a/src/authZConfig.ts
+++ b/src/authZConfig.ts
@@ -22,11 +22,11 @@ export const scopeRule: ScopeRule = {
     },
 };
 
-export function createAuthZConfig(
+export async function createAuthZConfig(
     expectedAudValue: string | RegExp,
     expectedIssValue: string,
     jwksEndpoint: string,
-): SMARTConfig {
+): Promise<SMARTConfig> {
     return {
         version: 1.0,
         scopeKey: 'scp',

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,13 +56,16 @@ const expectedAudValue = enableMultiTenancy
     : apiUrl;
 
 const fhirVersion: FhirVersion = '4.0.1';
-const authService = IS_OFFLINE
-    ? stubs.passThroughAuthz
-    : new SMARTHandler(
-          createAuthZConfig(expectedAudValue, issuerEndpoint, `${oAuth2ApiEndpoint}/keys`),
-          apiUrl,
-          fhirVersion,
-      );
+const getAuthService = async () => {
+    return IS_OFFLINE
+        ? stubs.passThroughAuthz
+        : new SMARTHandler(
+              await createAuthZConfig(expectedAudValue, issuerEndpoint, `${oAuth2ApiEndpoint}/keys`),
+              apiUrl,
+              fhirVersion,
+          );
+};
+
 const baseResources = fhirVersion === '4.0.1' ? BASE_R4_RESOURCES : BASE_STU3_RESOURCES;
 const dynamoDbDataService = new DynamoDbDataService(DynamoDb, false, { enableMultiTenancy });
 const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb, undefined, undefined, {
@@ -99,13 +102,13 @@ const esSearch = new ElasticSearchService(
 );
 const s3DataService = new S3DataService(dynamoDbDataService, fhirVersion, { enableMultiTenancy });
 
-export const fhirConfig: FhirConfig = {
+export const getFhirConfig = async (): Promise<FhirConfig> => ({
     configVersion: 1.0,
     productInfo: {
         orgName: 'Organization Name',
     },
     auth: {
-        authorization: authService,
+        authorization: await getAuthService(),
         // Used in Capability Statement Generation only
         strategy: {
             service: 'SMART-on-FHIR',
@@ -159,6 +162,6 @@ export const fhirConfig: FhirConfig = {
               tenantIdClaimPath: 'tenantId',
           }
         : undefined,
-};
+});
 
 export const genericResources = baseResources;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,30 @@
 
 import serverless from 'serverless-http';
 import { generateServerlessRouter } from 'fhir-works-on-aws-routing';
-import { fhirConfig, genericResources } from './config';
+import { getFhirConfig, genericResources } from './config';
 
-const serverlessHandler = serverless(generateServerlessRouter(fhirConfig, genericResources), {
-    request(request: any, event: any) {
-        request.user = event.user;
-    },
-});
+const ensureAsyncInit = async (initPromise: Promise<any>): Promise<void> => {
+    try {
+        await initPromise;
+    } catch (e) {
+        console.error('Async initialization failed', e);
+        // Explicitly exit the process so that next invocation re-runs the init code.
+        // This prevents Lambda containers from caching a rejected init promise
+        process.exit(1);
+    }
+};
+
+async function asyncServerless() {
+    return serverless(generateServerlessRouter(await getFhirConfig(), genericResources), {
+        request(request: any, event: any) {
+            request.user = event.user;
+        },
+    });
+}
+
+const serverlessHandler: Promise<any> = asyncServerless();
 
 export default async (event: any = {}, context: any = {}): Promise<any> => {
-    return serverlessHandler(event, context);
+    await ensureAsyncInit(serverlessHandler);
+    return (await serverlessHandler)(event, context);
 };


### PR DESCRIPTION
This allows customers to make async calls when building the FhirConfig. This can be useful for example to fetch configuration from AWS Systems Manager Parameter Store.

There are no functional changes.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [n/a] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
