### PR TITLE
docs: normalize placeholder variable names; clarify Postman instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -222,8 +222,8 @@ Log into your AWS account, navigate to the IAM service, and create a new User. T
 Note down the below IAM user’s properties for further use later in the process.
 
 - ACCESS_KEY
-- SECRET-KEY
-- IAM USER ARN
+- SECRET_KEY
+- IAM_USER_ARN
 
 Use these credentials to create a new profile in the AWS credentials file based on these instructions:
 
@@ -254,11 +254,11 @@ Create a new file in the package's root folder named
 
 > serverless_config.json
 
-In the _serverless_config.json_ file, add the following, using the previously noted IAM USER ARN.
+In the _serverless_config.json_ file, add the following, using the previously noted IAM_USER_ARN.
 
 ```json
 {
-  "devAwsUserAccountArn": "<IAM USER ARN>"
+  "devAwsUserAccountArn": "<IAM_USER_ARN>"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ After you import the collection, set up your environment. You can set up a local
 
 **Setting up environment variables**
 
-Set up the following three environment variables:
+Set up the following three Postman environments:
 
 + `Fhir_Local_Env.json`
 + `Fhir_Dev_Env.json`


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Updated documentation to normalize use of placeholder variable
Postman documentation refers to files containing various environments, not variable

Checklist:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
