### PR TITLE
fix: update ElasticSearch type to have more region support

### DIFF
--- a/cloudformation/elasticsearch.yaml
+++ b/cloudformation/elasticsearch.yaml
@@ -3,6 +3,79 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
+Mappings:
+  # For the most up to date ec2 types see: https://aws.amazon.com/opensearch-service/pricing/
+  RegionEC2Map:
+    us-east-2:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    us-east-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    us-west-1:
+      dev: c6g.large.elasticsearch
+      prod: r6g.large.elasticsearch
+    us-west-2:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    af-south-1:
+      dev: c5.large.elasticsearch
+      prod: m5.large.elasticsearch
+    ap-east-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    ap-south-1:
+      dev: c6g.large.elasticsearch
+      prod: r6g.large.elasticsearch
+    ap-northeast-3:
+      dev: c5.large.elasticsearch
+      prod: m5.large.elasticsearch
+    ap-northeast-2:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    ap-southeast-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    ap-southeast-2:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    ap-northeast-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    ca-central-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    eu-central-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    eu-west-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    eu-west-2:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    eu-south-1:
+      dev: c5.large.elasticsearch
+      prod: m5.large.elasticsearch
+    eu-west-3:
+      dev: c5.large.elasticsearch
+      prod: m5.large.elasticsearch
+    eu-north-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    me-south-1:
+      dev: c5.large.elasticsearch
+      prod: m5.large.elasticsearch
+    sa-east-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    us-gov-east-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+    us-gov-west-1:
+      dev: c6g.large.elasticsearch
+      prod: m6g.large.elasticsearch
+
 Resources:
   KibanaUserPool:
     Type: AWS::Cognito::UserPool
@@ -100,11 +173,16 @@ Resources:
         VolumeType: gp2
         VolumeSize: !If [isDev, 10, 73]
       ElasticsearchClusterConfig:
-        InstanceType: !If [isDev, c6g.large.elasticsearch, r6g.large.elasticsearch]
+        InstanceType:
+          !If [
+            isDev,
+            !FindInMap [RegionEC2Map, !Ref AWS::Region, dev],
+            !FindInMap [RegionEC2Map, !Ref AWS::Region, prod],
+          ]
         InstanceCount: !If [isDev, 1, 4]
         DedicatedMasterEnabled: !If [isDev, false, true]
         DedicatedMasterCount: !If [isDev, !Ref AWS::NoValue, 3]
-        DedicatedMasterType: !If [isDev, !Ref AWS::NoValue, c6g.large.elasticsearch]
+        DedicatedMasterType: !If [isDev, !Ref AWS::NoValue, !FindInMap [RegionEC2Map, !Ref AWS::Region, dev]]
         ZoneAwarenessEnabled: !If [isDev, false, true]
       ElasticsearchVersion: '7.10'
       EncryptionAtRestOptions:

--- a/cloudformation/elasticsearch.yaml
+++ b/cloudformation/elasticsearch.yaml
@@ -100,7 +100,7 @@ Resources:
         VolumeType: gp2
         VolumeSize: !If [isDev, 10, 73]
       ElasticsearchClusterConfig:
-        InstanceType: !If [isDev, c6g.large.elasticsearch, m6g.large.elasticsearch]
+        InstanceType: !If [isDev, c6g.large.elasticsearch, r6g.large.elasticsearch]
         InstanceCount: !If [isDev, 1, 4]
         DedicatedMasterEnabled: !If [isDev, false, true]
         DedicatedMasterCount: !If [isDev, !Ref AWS::NoValue, 3]


### PR DESCRIPTION
Description of changes:
- m6g ec2 type is not as widely available as r6g (specifically us-west-1). Switching to use r6g.

Cost & differences (region: us-east-1):

| Type| vCPU|RAM|Cost|
| --- | ----------- |----------- |----------- |
|r6g.large.search | 2 | 16 |  $0.167|
|m6g.large.search | 2 | 8 |  $0.128|
|m5.large.search | 2 | 8 |  $0.142|

https://aws.amazon.com/opensearch-service/pricing/

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
