### PR TITLE
chore: do not recast the Error

### DIFF
--- a/integration-tests/bulkExportTestHelper.ts
+++ b/integration-tests/bulkExportTestHelper.ts
@@ -125,7 +125,7 @@ export default class BulkExportTestHelper {
             return response.data;
         } catch (e) {
             console.log('Failed to preload data into DB', e);
-            throw new Error(e);
+            throw e;
         }
     }
 
@@ -152,7 +152,7 @@ export default class BulkExportTestHelper {
             return response.data;
         } catch (e) {
             console.log('Failed to preload group data into DB', e);
-            throw new Error(e);
+            throw e;
         }
     }
 


### PR DESCRIPTION
`tsc` on this file produces this error:
```
integration-tests/bulkExportTestHelper.ts:128:29 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string | undefined'.
```

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
