### PR TITLE
chore: update bulk tests to not allow user scopes

### DIFF
--- a/integration-tests/bulkExport.test.ts
+++ b/integration-tests/bulkExport.test.ts
@@ -19,8 +19,10 @@ describe('Bulk Export', () => {
 
         beforeAll(async () => {
             const fhirUserAxios = await getFhirClient('fhirUser user/*.*', true);
-
-            bulkExportTestHelper = new BulkExportTestHelper(fhirUserAxios);
+            const systemScopeFhirClient = await getFhirClient('fhirUser system/*.*', true);
+            bulkExportTestHelper = new BulkExportTestHelper(systemScopeFhirClient, {
+                bundleClientOverride: fhirUserAxios,
+            });
         });
 
         test('Successfully export all data added to DB after currentTime', async () => {
@@ -71,6 +73,20 @@ describe('Bulk Export', () => {
             await bulkExportTestHelper.stopExportJob(statusPollUrl);
             // CHECK
             return bulkExportTestHelper.getExportStatus(statusPollUrl, 'Export job has been canceled');
+        });
+
+        test('Ensure just `user` scope cannot do a system export', async () => {
+            // BUILD
+            const fhirUserAxios = await getFhirClient('fhirUser user/*.*', true);
+            const userTestHelper = new BulkExportTestHelper(fhirUserAxios);
+            // OPERATE & Check
+            // Only export resources that were added after 'currentTime'
+            await expect(userTestHelper.startExportJob({})).rejects.toMatchObject({
+                response: {
+                    status: 401,
+                    statusText: 'Unauthorized',
+                },
+            });
         });
     });
     describe('group export', () => {

--- a/integration-tests/bulkExport.test.ts
+++ b/integration-tests/bulkExport.test.ts
@@ -75,7 +75,7 @@ describe('Bulk Export', () => {
             return bulkExportTestHelper.getExportStatus(statusPollUrl, 'Export job has been canceled');
         });
 
-        test('Ensure just `user` scope cannot do a system export', async () => {
+        test('Ensure `user` scope cannot do a system export', async () => {
             // BUILD
             const fhirUserAxios = await getFhirClient('fhirUser user/*.*', true);
             const userTestHelper = new BulkExportTestHelper(fhirUserAxios);


### PR DESCRIPTION
Description of changes:
Due to [smart-authz dependency change](https://github.com/awslabs/fhir-works-on-aws-authz-smart/blob/mainline/CHANGELOG.md#300-2021-09-15) we no longer allow only `user` scopes to do the export. This commit updates our tests to reflect that.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
