### PR TITLE
chore: update bulk export multitenancy tests

### DIFF
--- a/integration-tests/multitenancy.test.ts
+++ b/integration-tests/multitenancy.test.ts
@@ -118,7 +118,12 @@ if (process.env.MULTI_TENANCY_ENABLED === 'true') {
 
         test('tenant cannot EXPORT resources from another tenant', async () => {
             const testPatient: ReturnType<typeof randomPatient> = (await client.post('Patient', randomPatient())).data;
-            const bulkExportTestHelper = new BulkExportTestHelper(clientForAnotherTenant);
+            const clientForAnotherTenantSystem = await getFhirClient('fhirUser system/*.*', true, {
+                tenant: 'tenant2',
+            });
+            const bulkExportTestHelper = new BulkExportTestHelper(clientForAnotherTenantSystem, {
+                bundleClientOverride: clientForAnotherTenant,
+            });
 
             const testPatientFromAnotherTenant: ReturnType<typeof randomPatient> = (
                 await clientForAnotherTenant.post('Patient', randomPatient())


### PR DESCRIPTION
Description of changes:
Update the multi-tenancy integ test to use `system` scope and not `user`

Similar update as: https://github.com/awslabs/fhir-works-on-aws-deployment/commit/d66b96fb44265fd4e7d272b5440529881264e1bd

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
