### PR TITLE
feat: add jobOwnerId as metadata on export results

### DIFF
--- a/bulkExport/glueScripts/export-script.py
+++ b/bulkExport/glueScripts/export-script.py
@@ -23,7 +23,7 @@ from datetime import datetime
 glueContext = GlueContext(SparkContext.getOrCreate())
 job = Job(glueContext)
 
-args = getResolvedOptions(sys.argv, ['JOB_NAME', 'jobId', 'exportType', 'transactionTime', 'since', 'outputFormat', 'ddbTableName', 'workerType', 'numberWorkers', 's3OutputBucket'])
+args = getResolvedOptions(sys.argv, ['JOB_NAME', 'jobId', 'jobOwnerId', 'exportType', 'transactionTime', 'since', 'outputFormat', 'ddbTableName', 'workerType', 'numberWorkers', 's3OutputBucket'])
 
 # type and tenantId are optional parameters
 type = None
@@ -46,6 +46,7 @@ if ('--{}'.format('groupId') in sys.argv):
    transitive_reference_param_file = "transitiveReferenceParams.json"
 
 job_id = args['jobId']
+job_owner_id = args['jobOwnerId']
 export_type = args['exportType']
 transaction_time = args['transactionTime']
 since = args['since']
@@ -263,6 +264,14 @@ else:
             'Bucket': bucket_name,
             'Key': source_s3_file_path
         }
-        client.copy(copy_source, bucket_name, new_s3_file_path)
+
+        extra_args = {
+            'Metadata': {
+                'job-owner-id': job_owner_id
+            },
+            'MetadataDirective':'REPLACE'
+        }
+
+        client.copy(copy_source, bucket_name, new_s3_file_path, ExtraArgs=extra_args)
         client.delete_object(Bucket=bucket_name, Key=source_s3_file_path)
     print('Export job finished')

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "aws-sdk": "^2.1000.0",
     "axios": "^0.21.4",
     "fhir-works-on-aws-authz-rbac": "5.0.0",
-    "fhir-works-on-aws-interface": "11.1.0",
-    "fhir-works-on-aws-persistence-ddb": "3.8.2",
-    "fhir-works-on-aws-routing": "6.1.2",
+    "fhir-works-on-aws-interface": "11.2.0",
+    "fhir-works-on-aws-persistence-ddb": "3.9.0",
+    "fhir-works-on-aws-routing": "6.2.0",
     "fhir-works-on-aws-search-es": "3.6.0",
     "serverless-http": "^2.3.1",
     "yargs": "^16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1907,7 +1907,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
-"@types/aws-lambda@^8.10.56", "@types/aws-lambda@^8.10.63":
+"@types/aws-lambda@^8.10.56", "@types/aws-lambda@^8.10.83":
   version "8.10.84"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.84.tgz#b1f391ceeb6908b28d8416d93f27afe8d1348d4e"
   integrity sha512-5V78eLtmN0d4RA14hKDwcsMQRl3JotQJlhGFDBo/jdE2TyDFRaYwB/UmMUC4SzhSvRGn+YMkh7jGPnXi8COAng==
@@ -2864,7 +2864,7 @@ aws-elasticsearch-connector@^8.2.0:
     aws4 "^1.10.0"
     lodash.get "^4.4.2"
 
-aws-sdk@^2.1000.0, aws-sdk@^2.610.0, aws-sdk@^2.856.0, aws-sdk@^2.859.0:
+aws-sdk@^2.1000.0, aws-sdk@^2.859.0:
   version "2.1006.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1006.0.tgz#fc2f7e267d19a6297f732e19449461bb944682af"
   integrity sha512-lwXAy706+1HVQqMnHaahdeBZZbdu6TWrtTY0ydeG0qanwldTFNMLczwnETTZWYsqNAU+wjl1VzmFdMO4gePLNQ==
@@ -2917,7 +2917,7 @@ aws-xray-sdk-postgres@3.3.3:
   dependencies:
     "@types/pg" "*"
 
-aws-xray-sdk@^3.1.0, aws-xray-sdk@^3.2.0:
+aws-xray-sdk@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/aws-xray-sdk/-/aws-xray-sdk-3.3.3.tgz#c2536bd2fd39d4606d81a17d5e364a2d7a6fa4f1"
   integrity sha512-bGO/HolPGW8N39wUuERbn0GPlwgAmDrgt7nKYXR2ecRq2YauKQOHS8K+kD4aZ6QSZnlP5CrYMmtU6BnMkt3DUQ==
@@ -5584,10 +5584,10 @@ fhir-works-on-aws-authz-rbac@5.0.0:
     jsonwebtoken "^8.5.1"
     lodash "^4.17.20"
 
-fhir-works-on-aws-interface@11.1.0, fhir-works-on-aws-interface@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.1.0.tgz#5950cb0538f831b6b2b34a0c83ab411c5a4e521c"
-  integrity sha512-wqLc3AFX8NwHQl5Ps406ozwz5LqXqKzXynicHbmsM8e29Hsb8tGS8+p2sXvhG9y+/DBj7QJljcJYN69F0eBt0g==
+fhir-works-on-aws-interface@11.2.0, fhir-works-on-aws-interface@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.2.0.tgz#2e12b3406ace4e24df8a18a827c50b834b633339"
+  integrity sha512-in2KVLKNfHPmJBwDNZrnJKg6VUrLncgBeL5Ow6ZE0tLxILBzZLNK7KWfcPlH3l6jQ4N9HLcF/GrOAGsGUGjHyQ==
   dependencies:
     winston "^3.3.3"
     winston-transport "^4.4.0"
@@ -5600,38 +5600,46 @@ fhir-works-on-aws-interface@^10.0.0:
     winston "^3.3.3"
     winston-transport "^4.4.0"
 
-fhir-works-on-aws-persistence-ddb@3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-persistence-ddb/-/fhir-works-on-aws-persistence-ddb-3.8.2.tgz#def813509562bc8e9e5148d39c875b8060456528"
-  integrity sha512-BiXuD2cLwlaC8+2ruVlLg3NjatPZkl4V9nBzyh70mZMylUfgfQbqAmuLlH29ZnkXoWefet4RSYkXnqJJtESH4g==
+fhir-works-on-aws-interface@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.1.0.tgz#5950cb0538f831b6b2b34a0c83ab411c5a4e521c"
+  integrity sha512-wqLc3AFX8NwHQl5Ps406ozwz5LqXqKzXynicHbmsM8e29Hsb8tGS8+p2sXvhG9y+/DBj7QJljcJYN69F0eBt0g==
+  dependencies:
+    winston "^3.3.3"
+    winston-transport "^4.4.0"
+
+fhir-works-on-aws-persistence-ddb@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-persistence-ddb/-/fhir-works-on-aws-persistence-ddb-3.9.0.tgz#1b46d56d8dbfbdb059c78845c94d3923b3bde040"
+  integrity sha512-Q/M/UXnkB6d6OLRv/R0dVmzdrbaB5zJBm4857c39ccp1fomXjylRRzUABOi5d5Kys9qihJQqoszZRFjLwCB1Aw==
   dependencies:
     "@elastic/elasticsearch" "7.13.0"
-    "@types/aws-lambda" "^8.10.63"
+    "@types/aws-lambda" "^8.10.83"
     aws-elasticsearch-connector "^8.2.0"
-    aws-sdk "^2.610.0"
-    aws-xray-sdk "^3.1.0"
-    fhir-works-on-aws-interface "^11.1.0"
+    aws-sdk "^2.1000.0"
+    aws-xray-sdk "^3.3.3"
+    fhir-works-on-aws-interface "^11.2.0"
     flat "^5.0.2"
     lodash "^4.17.20"
     mime-types "^2.1.26"
     promise.allsettled "^1.0.2"
     uuid "^3.4.0"
 
-fhir-works-on-aws-routing@6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-routing/-/fhir-works-on-aws-routing-6.1.2.tgz#07b489fcb7a6f463a0799353ae802057a4c53c62"
-  integrity sha512-eFl+Pcl+qKmLSldzlWjPkXbiXcUdlOqR11RD7IFw14zQLbvVW0tCUuFkZkJwXxX6rZnnLEmVsz6Y3KBUWFKf/Q==
+fhir-works-on-aws-routing@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-routing/-/fhir-works-on-aws-routing-6.2.0.tgz#205da04986d56fffa42fab13b1c5fac00b29bdc1"
+  integrity sha512-z+0MlI2Ykdb3u88dknJqIRBmK3R6kQ2jp05uuhE9prT+YWuawO2xU/KP8yFrzHt7Xmzh/AQx5TUQkd1UpmD0UA==
   dependencies:
     "@types/cors" "^2.8.7"
     "@types/express-serve-static-core" "^4.17.2"
     ajv "^6.11.0"
     ajv-errors "^1.0.1"
-    aws-sdk "^2.856.0"
-    aws-xray-sdk "^3.2.0"
+    aws-sdk "^2.1000.0"
+    aws-xray-sdk "^3.3.3"
     cors "^2.8.5"
     errorhandler "^1.5.1"
     express "^4.17.1"
-    fhir-works-on-aws-interface "^11.1.0"
+    fhir-works-on-aws-interface "^11.2.0"
     flat "^5.0.0"
     http-errors "^1.8.0"
     lodash "^4.17.15"


### PR DESCRIPTION
set `jobOwnerId` as metadata on export results s3 files

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-persistence-ddb/pull/124

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [n/a] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
