### PR TITLE
fix: use correct content-type on s3 export results

### DIFF
--- a/bulkExport/glueScripts/export-script.py
+++ b/bulkExport/glueScripts/export-script.py
@@ -266,6 +266,7 @@ else:
         }
 
         extra_args = {
+            'ContentType':'application/fhir+ndjson',
             'Metadata': {
                 'job-owner-id': job_owner_id
             },


### PR DESCRIPTION
Setting the content-type in s3 to `application/fhir+ndjson` is the way to go. 
Now that we allow customers to optionally use custom bulk export results URLs (https://github.com/awslabs/fhir-works-on-aws-persistence-ddb/pull/123) this is even more important so that downloads have a consistent content-type.

* [x] Have you successfully deployed to an AWS account with your changes?
* [n/a] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
