### PR TITLE
fix: use correct content-type on s3 export results

### DIFF
--- a/bulkExport/glueScripts/export-script.py
+++ b/bulkExport/glueScripts/export-script.py
@@ -266,6 +266,7 @@ else:
         }
 
         extra_args = {
+            'ContentType':'application/fhir+ndjson',
             'Metadata': {
                 'job-owner-id': job_owner_id
             },


### PR DESCRIPTION
same as https://github.com/awslabs/fhir-works-on-aws-deployment/pull/496

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
