### PR TITLE
fix: Fix CloudWatch LogGroup name for auditLogMover

### DIFF
--- a/auditLogMover/serverless.yaml
+++ b/auditLogMover/serverless.yaml
@@ -22,7 +22,7 @@ provider:
     FHIR_SERVICE: 'fhir-service-${self:custom.region}-${self:custom.stage}'
   environment:
     CLOUDWATCH_EXECUTION_LOG_GROUP:
-      Fn::ImportValue: CloudwatchExecutionLogGroup-${opt:stage, self:provider.stage}
+      Fn::ImportValue: CloudwatchAccessLogGroup-${opt:stage, self:provider.stage}
     AUDIT_LOGS_BUCKET: !Ref AuditLogsBucket
     STAGE: ${opt:stage, self:provider.stage}
   variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._@'\",\\-\\/\\(\\)]+?)}" # Use this for allowing CloudFormation Pseudo-Parameters in your serverless.yml
@@ -36,7 +36,7 @@ provider:
         - 'logs:PutLogEvents'
       Effect: 'Allow'
       Resource:
-        Fn::ImportValue: CloudwatchExecutionLogGroup-${opt:stage, self:provider.stage}-Arn
+        Fn::ImportValue: CloudwatchAccessLogGroup-${opt:stage, self:provider.stage}-Arn
     - Action:
         - 'cloudwatch:PutMetricData'
       Effect: 'Allow'

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -791,6 +791,16 @@ resources:
         Condition: isDev
         Description: App client id for the provisioning ES Kibana users.
         Value: !Ref KibanaUserPoolClient
+      CloudwatchAccessLogGroup:
+        Description: Cloudwatch Access log group for storing request/responses for auditing purposes
+        Value: !Ref ApiGatewayLogGroup
+        Export:
+          Name: !Join ['-', [CloudwatchAccessLogGroup, !Ref Stage]]
+      CloudwatchAccessLogGroupArn:
+        Description: Cloudwatch Access log group ARN for storing request/responses for auditing purposes
+        Value: !GetAtt ApiGatewayLogGroup.Arn
+        Export:
+          Name: !Join ['-', [CloudwatchAccessLogGroup, !Ref Stage, Arn]]
       CloudwatchExecutionLogGroup:
         Description: Cloudwatch Execution log group for storing request/responses for auditing purposes
         Value: !Join ['', ['API-Gateway-Execution-Logs_', !Ref ApiGatewayRestApi, '/', !Ref Stage]]


### PR DESCRIPTION
Issue #, if available: [Issue 498](https://github.com/awslabs/fhir-works-on-aws-deployment/issues/498)

Description of changes:

* As part of [PR-252](https://github.com/awslabs/fhir-works-on-aws-deployment/pull/252) we changed the API Gateway log group from `Execution` to `Access` which meant that log group was not managed by APIGateway. With that change our new log group was managed by serverless but we didn't change our auditLogMover to point to the new log group. With this change we are ensuring that auditLogMover uses the correct log group when moving logs to S3.

More information on Access vs Execution logs [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)

Testing done:

* Verified that auditLogMover is able to launch the export job successfully
```
Response
{
  "daysExported": [
    "2021-10-21"
  ],
  "message": "Successfully kicked off export tasks"
}
``` 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
