### PR TITLE
fix: Fix CloudWatch LogGroup name for auditLogMover (#503)

### DIFF
--- a/auditLogMover/serverless.yaml
+++ b/auditLogMover/serverless.yaml
@@ -22,7 +22,7 @@ provider:
     FHIR_SERVICE: 'fhir-service-smart-${self:custom.region}-${self:custom.stage}'
   environment:
     CLOUDWATCH_EXECUTION_LOG_GROUP:
-      Fn::ImportValue: CloudwatchExecutionLogGroup-${opt:stage, self:provider.stage}
+      Fn::ImportValue: CloudwatchAccessLogGroup-${opt:stage, self:provider.stage}
     AUDIT_LOGS_BUCKET: !Ref AuditLogsBucket
     STAGE: ${opt:stage, self:provider.stage}
   variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._@'\",\\-\\/\\(\\)]+?)}" # Use this for allowing CloudFormation Pseudo-Parameters in your serverless.yml
@@ -36,7 +36,7 @@ provider:
         - 'logs:PutLogEvents'
       Effect: 'Allow'
       Resource:
-        Fn::ImportValue: CloudwatchExecutionLogGroup-${opt:stage, self:provider.stage}-Arn
+        Fn::ImportValue: CloudwatchAccessLogGroup-${opt:stage, self:provider.stage}-Arn
     - Action:
         - 'cloudwatch:PutMetricData'
       Effect: 'Allow'

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -740,6 +740,16 @@ resources:
         Condition: isDev
         Description: App client id for the provisioning ES Kibana users.
         Value: !Ref KibanaUserPoolClient
+      CloudwatchAccessLogGroup:
+        Description: Cloudwatch Access log group for storing request/responses for auditing purposes
+        Value: !Ref ApiGatewayLogGroup
+        Export:
+          Name: !Join ['-', [CloudwatchAccessLogGroup, !Ref Stage]]
+      CloudwatchAccessLogGroupArn:
+        Description: Cloudwatch Access log group ARN for storing request/responses for auditing purposes
+        Value: !GetAtt ApiGatewayLogGroup.Arn
+        Export:
+          Name: !Join ['-', [CloudwatchAccessLogGroup, !Ref Stage, Arn]]
       CloudwatchExecutionLogGroup:
         Description: Cloudwatch Execution log group for storing request/responses for auditing purposes
         Value: !Join ['', ['API-Gateway-Execution-Logs_', !Ref ApiGatewayRestApi, '/', !Ref Stage]]


### PR DESCRIPTION
cherry pick of https://github.com/awslabs/fhir-works-on-aws-deployment/pull/503

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
