### PR TITLE
chore: add git secrets scan

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,1 +1,2 @@
+# This file matches because of "βrazil nut" (It's silly that git secrets also scans this file, so we cannot write βrazil with a regular "B")
 javaHapiValidatorLambda/src/test/resources/testImplementationGuides-r4/us-core/ValueSet-us-core-allergy-substance.json

--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,1 @@
+javaHapiValidatorLambda/src/test/resources/testImplementationGuides-r4/us-core/ValueSet-us-core-allergy-substance.json

--- a/.github/workflows/build-and-validate.yaml
+++ b/.github/workflows/build-and-validate.yaml
@@ -35,6 +35,7 @@ jobs:
           yarn release
 
   scan-for-secrets:
+    # AKIA111111111EXAMPLE
     name: Scan for secrets
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-and-validate.yaml
+++ b/.github/workflows/build-and-validate.yaml
@@ -35,7 +35,6 @@ jobs:
           yarn release
 
   scan-for-secrets:
-    # AKIA111111111EXAMPLE
     name: Scan for secrets
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-and-validate.yaml
+++ b/.github/workflows/build-and-validate.yaml
@@ -33,3 +33,23 @@ jobs:
           yarn release
           cd ..
           yarn release
+
+  scan-for-secrets:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Git Secrets
+        run: |
+          cd ~
+          git clone https://github.com/awslabs/git-secrets.git && cd git-secrets
+          sudo make install
+          git secrets --register-aws --global
+          git secrets --add '[aA]pollo|[bB]razil|[cC]oral|[oO]din' --global
+          git secrets --add 'tt\.amazon\.com|t\.corp\.amazon\.com|issues\.amazon\.com|sim\.amazon\.com|cr\.amazon\.com' --global
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Git Secrets
+        run: git secrets --scan
+      - name: Print remediation message
+        if: failure()
+        run: echo "git secrets found potential leaked credentials. If ANY credentials were committed, they MUST be immediately revoked."


### PR DESCRIPTION
Run `git secrets --scan` against all PRs

Test run that blocked a PR with a (fake) secret: https://github.com/awslabs/fhir-works-on-aws-deployment/runs/4098397011?check_suite_focus=true


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
