### PR TITLE
fix: glue export security name not unique

### DIFF
--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -203,7 +203,7 @@ Resources:
         JobBookmarksEncryption:
           KmsKeyArn: !GetAtt LogKMSKey.Arn
           JobBookmarksEncryptionMode: CSE-KMS
-      Name: 'export-security-config'
+      Name: !Join ['-', ['export-security-config', !Ref Stage, !Ref AWS::Region]]
     DependsOn:
       - LogKMSKey
 

--- a/cloudformation/bulkExport.yaml
+++ b/cloudformation/bulkExport.yaml
@@ -203,7 +203,7 @@ Resources:
         JobBookmarksEncryption:
           KmsKeyArn: !GetAtt LogKMSKey.Arn
           JobBookmarksEncryptionMode: CSE-KMS
-      Name: !Join ['-', ['export-security-config', !Ref Stage, !Ref AWS::Region]]
+      Name: !Join ['-', ['fhir-works-export-security-config', !Ref Stage, !Ref AWS::Region]]
     DependsOn:
       - LogKMSKey
 

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -428,7 +428,7 @@ resources:
           IdentitySource: method.request.header.Authorization
           RestApiId: !Ref ApiGatewayRestApi
           Type: COGNITO_USER_POOLS
-          Name: !Join ['-', [Authorizer, !Ref Stage, !Ref AWS::Region]]
+          Name: !Join ['-', [fhir-works-authorizer, !Ref Stage, !Ref AWS::Region]]
           ProviderARNs:
             - !Join [
                 '',

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -428,7 +428,7 @@ resources:
           IdentitySource: method.request.header.Authorization
           RestApiId: !Ref ApiGatewayRestApi
           Type: COGNITO_USER_POOLS
-          Name: Authorizer
+          Name: !Join ['-', [Authorizer, !Ref Stage, !Ref AWS::Region]]
           ProviderARNs:
             - !Join [
                 '',


### PR DESCRIPTION
Issue #512, if available:

Description of changes:
Revised export name of glue job security config to be unique across regions and stages.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
