### PR TITLE
feat: bump search version to 3.9.2

### DIFF
--- a/auditLogMover/package.json
+++ b/auditLogMover/package.json
@@ -42,7 +42,8 @@
     "normalize-url": "^4.5.1",
     "path-parse": "^1.0.7",
     "set-value": "^4.0.1",
-    "ansi-regex": "^5.0.1"
+    "ansi-regex": "^5.0.1",
+    "json-schema": "^0.4.0"
   },
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/auditLogMover/yarn.lock
+++ b/auditLogMover/yarn.lock
@@ -6657,10 +6657,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.2.3, json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"

--- a/integration-tests/search.test.ts
+++ b/integration-tests/search.test.ts
@@ -12,6 +12,7 @@ import {
     waitForResourceToBeSearchable,
     getResourcesFromBundleResponse,
     randomChainedParamBundle,
+    randomString,
 } from './utils';
 
 jest.setTimeout(600 * 1000);
@@ -72,7 +73,7 @@ describe('search', () => {
             p({ 'organization.name': resources.Organization.name }),
             p({ 'general-practitioner:PractitionerRole.organization.name': resources.Organization.name }),
             p({ 'general-practitioner:PractitionerRole.practitioner.family': resources.Practitioner.name[0].family }),
-            p({ 'general-practitioner:PractitionerRole.location.organization.name': resources.Location.name }),
+            p({ 'general-practitioner:PractitionerRole.location.organization.name': resources.Organization.name }),
             // Verify that chained parameters are combined with 'OR'
             p({
                 'organization.name': resources.Organization.name,
@@ -85,6 +86,25 @@ describe('search', () => {
         for (const testParams of testsParams) {
             // eslint-disable-next-line no-await-in-loop
             await expectResourceToBePartOfSearchResults(client, testParams, testPatient);
+        }
+
+        const randomStr = randomString();
+        const testsParamsThatDoNotMatch = [
+            p({ 'organization.name': randomStr }),
+            p({ 'general-practitioner:PractitionerRole.organization.name': randomStr }),
+            p({ 'general-practitioner:PractitionerRole.practitioner.family': randomStr }),
+            p({ 'general-practitioner:PractitionerRole.location.organization.name': randomStr }),
+            // Verify that chained parameters are combined with 'OR'
+            p({
+                'organization.name': randomStr,
+                'general-practitioner:PractitionerRole.practitioner.family': 'random-family-name-that-no-one-has',
+            }),
+        ];
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const testParams of testsParamsThatDoNotMatch) {
+            // eslint-disable-next-line no-await-in-loop
+            await expectResourceToNotBePartOfSearchResults(client, testParams, testPatient);
         }
     });
 
@@ -367,6 +387,7 @@ describe('search', () => {
             p({ identifier: 'someCode' }),
             p({ identifier: 'http://fwoa-integ-tests.com|' }),
             p({ identifier: 'somepatient@fwoa-mail.com' }),
+            p({ active: true }),
         ];
         // eslint-disable-next-line no-restricted-syntax
         for (const testParams of testsParamsThatMatch) {
@@ -384,6 +405,9 @@ describe('search', () => {
             p({ identifier: 'someOtherPatient@fwoa-mail.com' }),
             p({ identifier: 'somepatient' }),
             p({ identifier: 'fwoa-mail.com' }),
+            p({ identifier: 'http' }),
+            p({ identifier: 'someOtherPatient@fwoa' }),
+            p({ active: false }),
         ];
 
         // eslint-disable-next-line no-restricted-syntax

--- a/integration-tests/utils.ts
+++ b/integration-tests/utils.ts
@@ -382,6 +382,8 @@ export const expectResourceToNotBePartOfSearchResults = async (
 
 export const aFewMinutesAgoAsDate = () => new Date(Date.now() - 1000 * 60 * 10).toJSON();
 
+export const randomString = () => new Chance().string();
+
 export const expectResourceToBeInBundle = (resource: any, bundle: any) => {
     expect(bundle).toMatchObject({
         resourceType: 'Bundle',

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fhir-works-on-aws-interface": "11.3.0",
     "fhir-works-on-aws-persistence-ddb": "3.9.0",
     "fhir-works-on-aws-routing": "6.3.0",
-    "fhir-works-on-aws-search-es": "3.8.0",
+    "fhir-works-on-aws-search-es": "3.9.2",
     "serverless-http": "^2.7.0",
     "yargs": "^16.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "normalize-url": "^4.5.1",
     "path-parse": "^1.0.7",
     "set-value": "^4.0.1",
-    "ansi-regex": "^5.0.1"
+    "ansi-regex": "^5.0.1",
+    "json-schema": "^0.4.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7645,10 +7645,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.2.3, json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5566,10 +5566,10 @@ fhir-works-on-aws-routing@6.3.0:
     serverless-http "^2.3.1"
     uuid "^3.4.0"
 
-fhir-works-on-aws-search-es@3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-search-es/-/fhir-works-on-aws-search-es-3.8.0.tgz#042b1c7462acc8815b18a4d020477f56a6c9bd80"
-  integrity sha512-KarL+3cdmxswcd/SyTKyUq/QoOJORuLy+8jGSKhk9+ee30W8fWSAc436fy+OXgXeQj5QfRfOcFuNC9T4IZk5mQ==
+fhir-works-on-aws-search-es@3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-search-es/-/fhir-works-on-aws-search-es-3.9.2.tgz#be1f478dfce01a170f9619b08d6c1dcbf6ed2d9d"
+  integrity sha512-xgl9pLQ+miCPNSJmcZzTCzClvRe3rU1oaFKWsOgRKmu8l68VdLUAjgXc8AaG0FP5l/izfzkT/NpFVU6VSWv71g==
   dependencies:
     "@elastic/elasticsearch" "7.13"
     aws-elasticsearch-connector "^8.2.0"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Bump search version to 3.9.2
* Add integration test for Boolean token search
* Add integration test for chained param search that does not match 
* 2 dependabot fix 


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
