### PR TITLE
chore(deps): bump log4j-core from 2.13.2 to 2.15.0 in /javaHapiValida…

### DIFF
--- a/javaHapiValidatorLambda/pom.xml
+++ b/javaHapiValidatorLambda/pom.xml
@@ -105,12 +105,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.0</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
…torLambda (#519)

* chore(deps): bump log4j-api in /javaHapiValidatorLambda

Bumps log4j-api from 2.13.0 to 2.15.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

* chore(deps): bump log4j-core in /javaHapiValidatorLambda

Bumps log4j-core from 2.13.2 to 2.15.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

* bounce mainline protection check

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: zheyanyu <zheyanyu@amazon.com>

Issue #, if available:

Description of changes:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
