### PR TITLE
chore(deps): bump log4j-core and log4j-api from 2.16.0 to 2.17.0 in javaHapiValidatorLambda

### DIFF
--- a/javaHapiValidatorLambda/pom.xml
+++ b/javaHapiValidatorLambda/pom.xml
@@ -105,12 +105,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Issue #, if available:

Description of changes: Applying the same patches to `smart` that were applied via dependabot on mainline See [PR 529](https://github.com/awslabs/fhir-works-on-aws-deployment/pull/529) and [PR 530](https://github.com/awslabs/fhir-works-on-aws-deployment/pull/530)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
