### PR TITLE
chore(deps): bump log4j-api and log4j-core from 2.17.0 to 2.17.1

### DIFF
--- a/javaHapiValidatorLambda/pom.xml
+++ b/javaHapiValidatorLambda/pom.xml
@@ -105,12 +105,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION

Cherry pick and squash into `smart-develop` of 2 dependabot PRs:

- https://github.com/awslabs/fhir-works-on-aws-deployment/pull/535
- https://github.com/awslabs/fhir-works-on-aws-deployment/pull/534


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
