### PR TITLE
chore: rerun mainline protection check on PR edit 

### DIFF
--- a/.github/workflows/mainline-protection.yaml
+++ b/.github/workflows/mainline-protection.yaml
@@ -6,6 +6,7 @@
 name: Mainline Protection
 on:
   pull_request:
+    types: [opened, synchronize, edited, reopened]
     branches:
       - mainline
 # The purpose of this workflow is to create a failing Status check on pull request against mainline. This will prevent

--- a/.github/workflows/mainline-protection.yaml
+++ b/.github/workflows/mainline-protection.yaml
@@ -7,8 +7,6 @@ name: Mainline Protection
 on:
   pull_request:
     types: [opened, synchronize, edited, reopened]
-    branches:
-      - mainline
 # The purpose of this workflow is to create a failing Status check on pull request against mainline. This will prevent
 # PR from being merged into mainline.
 jobs:
@@ -16,4 +14,11 @@ jobs:
     name: Only create PR against develop branch, not mainline branch
     runs-on: ubuntu-18.04
     steps:
-      - run: failing-command # An invalid bash command to trigger failure of this workflow
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+      - name: mainline protection.
+          if: steps.branch-name.outputs.base_ref_branch == 'mainline'
+          run: |
+            echo "PR has target branch mainline. Failing workflow..."
+            exit 1

--- a/.github/workflows/mainline-protection.yaml
+++ b/.github/workflows/mainline-protection.yaml
@@ -17,12 +17,6 @@ jobs:
       - name: Get branch name
         id: branch-name
         uses: tj-actions/branch-names@v5.1
-      - name: echo branch names
-        run: |
-          echo "base_ref_branch: ${{ steps.branch-name.outputs.base_ref_branch }}"
-          echo "current_branch: ${{ steps.branch-name.outputs.current_branch }}"
-          echo "head_ref_branch: ${{ steps.branch-name.outputs.head_ref_branch }}"
-          echo "ref_branch: ${{ steps.branch-name.outputs.ref_branch }}"
       - name: mainline protection
         if: steps.branch-name.outputs.base_ref_branch == 'mainline' || steps.branch-name.outputs.base_ref_branch == 'smart-mainline'
         run: |

--- a/.github/workflows/mainline-protection.yaml
+++ b/.github/workflows/mainline-protection.yaml
@@ -17,6 +17,12 @@ jobs:
       - name: Get branch name
         id: branch-name
         uses: tj-actions/branch-names@v5.1
+      - name: echo branch names
+        run: |
+          echo "base_ref_branch: ${{ steps.branch-name.outputs.base_ref_branch }}"
+          echo "current_branch: ${{ steps.branch-name.outputs.current_branch }}"
+          echo "head_ref_branch: ${{ steps.branch-name.outputs.head_ref_branch }}"
+          echo "ref_branch: ${{ steps.branch-name.outputs.ref_branch }}"
       - name: mainline protection
         if: steps.branch-name.outputs.base_ref_branch == 'mainline' || steps.branch-name.outputs.base_ref_branch == 'smart-mainline'
         run: |

--- a/.github/workflows/mainline-protection.yaml
+++ b/.github/workflows/mainline-protection.yaml
@@ -11,14 +11,14 @@ on:
 # PR from being merged into mainline.
 jobs:
   mainline-protection:
-    name: Only create PR against develop branch, not mainline branch
+    name: Only create PR against develop branches, not mainline branches
     runs-on: ubuntu-18.04
     steps:
       - name: Get branch name
         id: branch-name
         uses: tj-actions/branch-names@v5.1
       - name: mainline protection
-        if: steps.branch-name.outputs.base_ref_branch == 'mainline'
+        if: steps.branch-name.outputs.base_ref_branch == 'mainline' || steps.branch-name.outputs.base_ref_branch == 'smart-mainline'
         run: |
-          echo "PR has target branch mainline. Failing workflow..."
+          echo "PR has target branch ${{ steps.branch-name.outputs.base_ref_branch }}. Failing workflow..."
           exit 1

--- a/.github/workflows/mainline-protection.yaml
+++ b/.github/workflows/mainline-protection.yaml
@@ -17,8 +17,8 @@ jobs:
       - name: Get branch name
         id: branch-name
         uses: tj-actions/branch-names@v5.1
-      - name: mainline protection.
-          if: steps.branch-name.outputs.base_ref_branch == 'mainline'
-          run: |
-            echo "PR has target branch mainline. Failing workflow..."
-            exit 1
+      - name: mainline protection
+        if: steps.branch-name.outputs.base_ref_branch == 'mainline'
+        run: |
+          echo "PR has target branch mainline. Failing workflow..."
+          exit 1


### PR DESCRIPTION
Now we can simply change the branch to `develop` to rerun the mainline protection check instead of having to push an empty commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
