### PR TITLE
fix: add deletion policy to KMS keys

### DIFF
--- a/cloudformation/kms.yaml
+++ b/cloudformation/kms.yaml
@@ -11,6 +11,8 @@ Resources:
       TargetKeyId: !Ref S3KMSKey
   S3KMSKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       EnableKeyRotation: true
       Description: 'KMS CMK for s3'
@@ -30,6 +32,8 @@ Resources:
       TargetKeyId: !Ref DynamodbKMSKey
   DynamodbKMSKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       EnableKeyRotation: true
       Description: 'KMS CMK for DynamoDB'


### PR DESCRIPTION
Description of changes:

Add deletion policy policy to KMS keys. Without this the deletion policy on DDB and S3 buckets was not effective since the KMS key would be deleted an customers would lose access to S3/DDB data even if the Bucket/Table was retained

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
