### PR TITLE
feat: Added lambda function for handling messages in ddbToEs DLQ

### DIFF
--- a/ddbToEsDlqLambda/index.ts
+++ b/ddbToEsDlqLambda/index.ts
@@ -1,0 +1,160 @@
+import AWS from 'aws-sdk';
+import { makeLogger } from 'fhir-works-on-aws-interface';
+
+let logger;
+const { QUEUE_URL, DDB_TO_ES_LAMBDA_NAME, MAX_NUMBER_OF_MESSAGES_TO_PROCESS } = process.env;
+const MESSAGE_BATCH_SIZE = 10;
+const MESSAGE_VISIBILITY_TIMEOUT = 30; // seconds
+const INVOCATION_TYPE = 'RequestResponse'; // synchronous invocation
+const sqs = new AWS.SQS();
+const lambda = new AWS.Lambda();
+const dynamodbstreams = new AWS.DynamoDBStreams();
+
+const getMessages = async (queueUrl, batchSize) => {
+    const resp = await sqs
+        .receiveMessage({
+            QueueUrl: queueUrl,
+            MaxNumberOfMessages: batchSize,
+            VisibilityTimeout: MESSAGE_VISIBILITY_TIMEOUT,
+            WaitTimeSeconds: 0,
+        })
+        .promise()
+        .catch((e) => {
+            throw new Error(`Failed to receive messages: ${JSON.stringify(e)}`);
+        });
+
+    // when there are no messages, resp.Messages is undefined
+    const messages = resp.Messages === undefined ? [] : resp.Messages;
+    logger.debug('Received messages', JSON.stringify(messages));
+    return messages;
+};
+
+const deleteMessages = async (queueUrl, messagesToDelete) => {
+    const resp = await sqs
+        .deleteMessageBatch({
+            QueueUrl: queueUrl,
+            Entries: messagesToDelete,
+        })
+        .promise()
+        .catch((e) => {
+            throw new Error(`Failed to delete messages: ${JSON.stringify(e)}`);
+        });
+
+    // resp.Successful contains successfully deleted messages.
+    if (resp.Successful) {
+        logger.debug('Deleted messages', JSON.stringify(resp.Successful));
+    }
+
+    // resp.Failed contains messages that were failed to be deleted
+    if (resp.Failed && resp.Failed.length) {
+        throw new Error(`Failed to delete messages: ${JSON.stringify(resp.Failed)}`);
+    }
+};
+
+const invokeDdbToEsLambda = async (records) => {
+    const resp = await lambda
+        .invoke({
+            FunctionName: DDB_TO_ES_LAMBDA_NAME,
+            InvocationType: INVOCATION_TYPE,
+            Payload: JSON.stringify(records),
+        })
+        .promise()
+        .catch((e) => {
+            throw new Error(`Failed to invoke DdbToEsLambda: ${JSON.stringify(e)}`);
+        });
+
+    // StatusCode 200 only means successful invocation.
+    if (resp.StatusCode >= 400) {
+        throw new Error(`Failed to invoke DdbToEsLambda: ${JSON.stringify(resp.Payload)}`);
+    }
+
+    // When errors occur during execution, StatusCode is 200, but FunctionError is present.
+    if (resp.FunctionError) {
+        throw new Error(`Failed to invoke DdbToEsLambda: ${JSON.stringify(resp.Payload)}`);
+    }
+
+    logger.debug('Invoked DdbToEsLambda with records', JSON.stringify(records));
+};
+
+const getRecordsFromDdbStream = async (message) => {
+    const resp = await dynamodbstreams
+        .getShardIterator({
+            ShardId: message.DDBStreamBatchInfo.shardId,
+            ShardIteratorType: 'AT_SEQUENCE_NUMBER',
+            StreamArn: message.DDBStreamBatchInfo.streamArn,
+            SequenceNumber: message.DDBStreamBatchInfo.startSequenceNumber,
+        })
+        .promise()
+        .catch((e) => {
+            throw new Error(`Failed to get shard iterator: ${JSON.stringify(e)}`);
+        });
+
+    const records = await dynamodbstreams
+        .getRecords({
+            ShardIterator: resp.ShardIterator,
+        })
+        .promise()
+        .catch((e) => {
+            throw new Error(`Failed to get records: ${JSON.stringify(e)}`);
+        });
+
+    logger.debug('Fetched records', JSON.stringify(records));
+    return records;
+};
+
+/**
+ * This Lambda function will read message from the DDbToEs DLQ, fetch records from the DynamoDB stream
+ * referenced in the queued message, and invoke the DDBToEs Lambda function providing the records as input.
+ *
+ * Note:
+ *   1. Message retention period is 14 days. After retention period, messages would be deleted automatically.
+ *   2. Record retention period is 24 hours. After retention period, records would be deleted automatically.
+ *   3. Message visibility timeout must be greater than the total time of processing the message,
+ *      otherwise the message would be received by this Lambda function again. Too long timeout would
+ *      make the messages invisible for long time, and it appears there are no messages in DLQ.
+ */
+exports.handler = async (event) => {
+    // Initializing the logger inside the handler would prevent logger from caching.
+    // This ensures log level changes would take effect immediately.
+    logger = makeLogger(
+        {
+            component: 'DdbToEsDlqLambda',
+        },
+        process.env.LOG_LEVEL,
+    );
+
+    let numMessagesToProcess = event.maxNumberOfMessages
+        ? event.maxNumberOfMessages
+        : Number(MAX_NUMBER_OF_MESSAGES_TO_PROCESS);
+
+    if (typeof numMessagesToProcess !== 'number' || numMessagesToProcess < 1) {
+        throw new Error(`invalid maxNumberOfMessages: ${numMessagesToProcess}`);
+    }
+
+    while (numMessagesToProcess > 0) {
+        // If SQS error is thrown, then stop processing messages.
+        /* eslint-disable no-await-in-loop */
+        const messages = await getMessages(
+            QUEUE_URL,
+            MESSAGE_BATCH_SIZE > numMessagesToProcess ? numMessagesToProcess : MESSAGE_BATCH_SIZE,
+        );
+        if (messages.length <= 0) {
+            // No further messages to process, stop here.
+            break;
+        }
+
+        numMessagesToProcess -= messages.length;
+        const messagesToDelete = [];
+        /* eslint-disable no-restricted-syntax */
+        for (const message of messages) {
+            const records = await getRecordsFromDdbStream(JSON.parse(message.Body));
+            await invokeDdbToEsLambda(records);
+            messagesToDelete.push({
+                Id: message.MessageId,
+                ReceiptHandle: message.ReceiptHandle,
+            });
+        }
+
+        await deleteMessages(QUEUE_URL, messagesToDelete);
+    }
+};

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -130,6 +130,17 @@ functions:
           batchSize: 15 # Lambda payload size limit ~6MB; DDB row limit ~400KB = 15 items
           maximumRetryAttempts: 3
           startingPosition: LATEST
+  
+  ddbToEsDlq:
+    timeout: 300
+    runtime: nodejs14.x
+    description: 'Read messages from ddbToEs DLQ, fetch records from DynamoDB stream and invoke ddbToEs lambda function.'
+    role: DdbToEsDlqLambdaRole
+    handler: ddbToEsDlqLambda/index.handler
+    environment:
+      QUEUE_URL: !Ref DdbToEsDLQ
+      DDB_TO_ES_LAMBDA_NAME: '${self:service}-${self:custom.stage}-ddbToEs'
+      MAX_NUMBER_OF_MESSAGES_TO_PROCESS: 100
 
   startExportJob:
     timeout: 30
@@ -639,6 +650,71 @@ resources:
                     Resource:
                       - !GetAtt DynamodbKMSKey.Arn
                       - !GetAtt ElasticSearchKMSKey.Arn
+      DdbToEsDlqLambdaRole:
+        Type: AWS::IAM::Role
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W11
+                reason: '* only applies to X-Ray statement which does not define a group or sampling-rule'
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: 'Allow'
+                Principal:
+                  Service: 'lambda.amazonaws.com'
+                Action: 'sts:AssumeRole'
+          Policies:
+            - PolicyName: 'DdbToEsDlqLambdaPolicy'
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - logs:CreateLogStream
+                      - logs:CreateLogGroup
+                      - logs:PutLogEvents
+                    Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:*:*'
+                  - Effect: Allow
+                    Action:
+                      - lambda:InvokeFunction
+                    Resource:
+                      - !GetAtt DdbToEsLambdaFunction.Arn
+                  - Effect: Allow
+                    Action:
+                      - xray:PutTraceSegments
+                      - xray:PutTelemetryRecords
+                    Resource:
+                      - '*'
+                  - Effect: Allow
+                    Action:
+                      - 'sqs:ReceiveMessage'
+                      - 'sqs:DeleteMessage'
+                    Resource:
+                      - !GetAtt DdbToEsDLQ.Arn
+                  - Effect: Allow
+                    Action:
+                      - 'dynamodb:GetShardIterator'
+                      - 'dynamodb:GetRecords'
+                    Resource:
+                      - !GetAtt ResourceDynamoDBTableV2.StreamArn
+            - PolicyName: 'KMSPolicy'
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - 'kms:Describe*'
+                      - 'kms:Get*'
+                      - 'kms:List*'
+                      - 'kms:Encrypt'
+                      - 'kms:Decrypt'
+                      - 'kms:ReEncrypt*'
+                      - 'kms:GenerateDataKey'
+                      - 'kms:GenerateDataKeyWithoutPlaintext'
+                    Resource:
+                      - !GetAtt DynamodbKMSKey.Arn
       UpdateSearchMappingsLambdaRole:
         Type: AWS::IAM::Role
         Metadata:


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Adding a Lambda function that would re-try the sync from DynamoDB table to ElasticSearch index.

More specifically, this Lambda function will read message from the DDbToEs DLQ, fetch records from the DynamoDB stream
referenced in the queued message, and invoke the DDBToEs Lambda function providing the records as input.

This Lambda function is expected to be triggered manually.
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
