### PR TITLE
feat: add permissions to BackupRole to allow restore operations

### DIFF
--- a/cloudformation/backup.yaml
+++ b/cloudformation/backup.yaml
@@ -52,6 +52,7 @@ Resources:
               - 'sts:AssumeRole'
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores'
 
   TagBasedBackupSelection:
     Type: 'AWS::Backup::BackupSelection'


### PR DESCRIPTION
Issue #, if available:
#546 

Description of changes:
Added AWS managed policy `AWSBackupServiceRolePolicyForRestores` to the fwoa BackupRole so restores can be executed without having to create a new role. Confirmed fhir-server-backups cloudformation stack successfully creates a BackupRole with `AWSBackupServiceRolePolicyForRestores` attached.

Checklist:

* [X ] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
