### PR TITLE
feat: subscriptionReaper

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -16,7 +16,7 @@ custom:
   config: ${file(serverless_config.json)}
   useHapiValidator: ${opt:useHapiValidator, 'false'}
   enableMultiTenancy: ${opt:enableMultiTenancy, 'false'}
-  enableSubscriptions: ${opt:enableSubscriptions, 'true'}
+  enableSubscriptions: ${opt:enableSubscriptions, 'false'}
   logLevel: ${opt:logLevel, 'error'}
   enableESHardDelete: ${opt:enableESHardDelete, 'false'}
   patientCompartmentFileV3: 'patientCompartmentSearchParams.3.0.2.json'

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -192,14 +192,17 @@ functions:
       ELASTICSEARCH_DOMAIN_ENDPOINT: !Join ['', ['https://', !GetAtt ElasticSearchDomain.DomainEndpoint]]
       NUMBER_OF_SHARDS: !If [isDev, 1, 3] # 133 indices, one per resource types
     
-    subscriptionReaper:
-      timeout: 30
-      runtime: nodejs14.x
-      description: 'Scheduled Lambda to remove expired Subscriptions'
-      handler: subscriptions/index.handler
-      events:
-        - schedule: rate(5 minutes)
-        - enable: ${self:custom.enableSubscriptions}
+  subscriptionReaper:
+    timeout: 30
+    runtime: nodejs14.x
+    description: 'Scheduled Lambda to remove expired Subscriptions'
+    handler: src/subscriptions/index.handler
+    events:
+      - schedule: rate(5 minutes)
+      - enable: ${self:custom.enableSubscriptions}
+    environment:
+      RESOURCE_TABLE: ${self:custom.resourceTableName}
+      ENABLE_MULTI_TENANCY: !Ref EnableMultiTenancy
 
 stepFunctions:
   stateMachines:

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -16,7 +16,7 @@ custom:
   config: ${file(serverless_config.json)}
   useHapiValidator: ${opt:useHapiValidator, 'false'}
   enableMultiTenancy: ${opt:enableMultiTenancy, 'false'}
-  enableSubscriptions: ${opt:enableSubscriptions, 'false'}
+  enableSubscriptions: ${opt:enableSubscriptions, 'true'}
   logLevel: ${opt:logLevel, 'error'}
   enableESHardDelete: ${opt:enableESHardDelete, 'false'}
   patientCompartmentFileV3: 'patientCompartmentSearchParams.3.0.2.json'
@@ -196,6 +196,7 @@ functions:
     timeout: 30
     runtime: nodejs14.x
     description: 'Scheduled Lambda to remove expired Subscriptions'
+    role: SubscriptionReaperRole
     handler: src/subscriptions/index.handler
     events:
       - schedule: rate(5 minutes)
@@ -769,6 +770,43 @@ resources:
                       - 'kms:GenerateDataKeyWithoutPlaintext'
                     Resource:
                       - !GetAtt ElasticSearchKMSKey.Arn
+      SubscriptionReaperRole:
+        Type: AWS::IAM::Role
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: 'Allow'
+                Principal:
+                  Service: 'lambda.amazonaws.com'
+                Action: 'sts:AssumeRole'
+          Policies:
+            - PolicyName: 'SubscriptionReaperPolicy'
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - dynamodb:DeleteResource
+                      - dynamodb:Query
+                    Resource:
+                      - !Join ['', [!GetAtt ResourceDynamoDBTableV2.Arn, '/*']]
+            - PolicyName: 'KMSPolicy'
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - 'kms:Describe*'
+                      - 'kms:Get*'
+                      - 'kms:List*'
+                      - 'kms:Encrypt'
+                      - 'kms:Decrypt'
+                      - 'kms:ReEncrypt*'
+                      - 'kms:GenerateDataKey'
+                      - 'kms:GenerateDataKeyWithoutPlaintext'
+                    Resource:
+                      - !GetAtt DynamodbKMSKey.Arn
       DdbToEsDLQ:
         Type: AWS::SQS::Queue
         Properties:

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -199,9 +199,8 @@ functions:
     handler: src/subscriptions/index.handler
     events:
       - schedule: rate(5 minutes)
-      - enable: ${self:custom.enableSubscriptions}
+      - enable: ${self:custom.enableSubscriptions} # will only run if opted into subscription feature
     environment:
-      RESOURCE_TABLE: ${self:custom.resourceTableName}
       ENABLE_MULTI_TENANCY: !Ref EnableMultiTenancy
 
 stepFunctions:

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -16,7 +16,7 @@ custom:
   config: ${file(serverless_config.json)}
   useHapiValidator: ${opt:useHapiValidator, 'false'}
   enableMultiTenancy: ${opt:enableMultiTenancy, 'false'}
-  enableSubscriptions: ${opt:enableSubscriptions, 'false'}
+  enableSubscriptions: ${opt:enableSubscriptions, 'true'}
   logLevel: ${opt:logLevel, 'error'}
   enableESHardDelete: ${opt:enableESHardDelete, 'false'}
   patientCompartmentFileV3: 'patientCompartmentSearchParams.3.0.2.json'
@@ -596,6 +596,7 @@ resources:
                       - 'dynamodb:BatchWriteItem'
                     Resource:
                       - !GetAtt ResourceDynamoDBTableV2.Arn
+                      - !Join ['', [!GetAtt ResourceDynamoDBTableV2.Arn, '/index/*']]
                       - !GetAtt ExportRequestDynamoDBTable.Arn
                   - Effect: Allow
                     Action:
@@ -787,10 +788,11 @@ resources:
                 Statement:
                   - Effect: Allow
                     Action:
-                      - dynamodb:DeleteResource
+                      - dynamodb:UpdateItem
                       - dynamodb:Query
                     Resource:
-                      - !Join ['', [!GetAtt ResourceDynamoDBTableV2.Arn, '/*']]
+                      - !Join ['', [!GetAtt ResourceDynamoDBTableV2.Arn, '/index/*']]
+                      - !GetAtt ResourceDynamoDBTableV2.Arn
             - PolicyName: 'KMSPolicy'
               PolicyDocument:
                 Version: '2012-10-17'

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -191,6 +191,15 @@ functions:
     environment:
       ELASTICSEARCH_DOMAIN_ENDPOINT: !Join ['', ['https://', !GetAtt ElasticSearchDomain.DomainEndpoint]]
       NUMBER_OF_SHARDS: !If [isDev, 1, 3] # 133 indices, one per resource types
+    
+    subscriptionReaper:
+      timeout: 30
+      runtime: nodejs14.x
+      description: 'Scheduled Lambda to remove expired Subscriptions'
+      handler: subscriptions/index.handler
+      events:
+        - schedule: rate(5 minutes)
+        - enable: ${self:custom.enableSubscriptions}
 
 stepFunctions:
   stateMachines:

--- a/src/subscriptions/index.ts
+++ b/src/subscriptions/index.ts
@@ -4,10 +4,6 @@
  *
  */
 
-
-/**
- * Custom lambda handler that handles deleting expired subscriptions.
- */
 import reaperHandler from './subscriptionReaper';
 import RestHookHandler from './restHook';
 import { AllowListInfo, getAllowListInfo } from './allowListUtil';
@@ -23,4 +19,8 @@ const restHookHandler = new RestHookHandler({ enableMultitenancy });
 exports.handler = async (event: any) => {
     return restHookHandler.sendRestHookNotification(event, allowListPromise);
 };
+
+/**
+ * Custom lambda handler that handles deleting expired subscriptions.
+ */
 exports.reaperHandler = reaperHandler;

--- a/src/subscriptions/index.ts
+++ b/src/subscriptions/index.ts
@@ -4,7 +4,7 @@
  *
  */
 
-import { reaperHandler } from './subscriptionReaper';
+import reaperHandler from './subscriptionReaper';
 
 /**
  * Custom lambda handler that handles deleting expired subscriptions.

--- a/src/subscriptions/index.ts
+++ b/src/subscriptions/index.ts
@@ -5,7 +5,13 @@
  */
 
 import axios from 'axios';
+import AWS from 'aws-sdk';
 import { DynamoDbDataService } from 'fhir-works-on-aws-persistence-ddb/src/dataServices/dynamoDbDataService';
+
+const enableMultiTenancy = process.env.ENABLE_MULTI_TENANCY === 'true';
+const dbService = new DynamoDbDataService(new AWS.DynamoDB(), false, {
+    enableMultiTenancy: enableMultiTenancy,
+});
 
 const sendCfnResponse = async (event: any, status: 'SUCCESS' | 'FAILED', error?: Error) => {
     if (error !== undefined) {
@@ -29,9 +35,26 @@ const sendCfnResponse = async (event: any, status: 'SUCCESS' | 'FAILED', error?:
  * Custom lambda handler that handles deleting expired subscriptions.
  */
 exports.handler = async (event: any) => {
-    console.log(event);
     try {
-        
+        const subscriptions = await dbService.getActiveSubscriptions({});
+        const currentTime = new Date();
+        let subTime;
+        const deletions: Promise<{
+            success: boolean,
+            message: string,
+        }>[] = [];
+        // filter out subscriptions without a defined end time.
+        subscriptions.filter(s => s.end).forEach(subscription => {
+            // check if subscription is past its end date (ISO format)
+            // example format of subscriptions: https://www.hl7.org/fhir/subscription-example.json.html
+            subTime = new Date(subscription.end);
+            if (currentTime >= subTime) {
+                // delete the subscription as it has reached its end time
+                deletions.push(dbService.deleteResource({ resourceType: subscription.resourceType, id: subscription.id }));
+            }
+        });
+        await Promise.all(deletions);
+        await sendCfnResponse(event, 'SUCCESS');
     } catch (e) {
         await sendCfnResponse(event, 'FAILED', e);
     }

--- a/src/subscriptions/index.ts
+++ b/src/subscriptions/index.ts
@@ -4,58 +4,9 @@
  *
  */
 
-import axios from 'axios';
-import AWS from 'aws-sdk';
-import { DynamoDbDataService } from 'fhir-works-on-aws-persistence-ddb/src/dataServices/dynamoDbDataService';
-
-const enableMultiTenancy = process.env.ENABLE_MULTI_TENANCY === 'true';
-const dbService = new DynamoDbDataService(new AWS.DynamoDB(), false, {
-    enableMultiTenancy: enableMultiTenancy,
-});
-
-const sendCfnResponse = async (event: any, status: 'SUCCESS' | 'FAILED', error?: Error) => {
-    if (error !== undefined) {
-        console.log(error);
-    }
-    const responseBody = JSON.stringify({
-        Status: status,
-        Reason: error?.message,
-        // The value of PhysicalResourceId doesn't really matter in this case.
-        // It just needs to be the same string on all responses to indicate that it is the same resource.
-        PhysicalResourceId: 'subscriptionReaper',
-        StackId: event.StackId,
-        RequestId: event.RequestId,
-        LogicalResourceId: event.LogicalResourceId,
-    });
-    console.log(`Sending response to CFN: ${responseBody}`);
-    await axios.put(event.ResponseURL, responseBody);
-};
+import { reaperHandler } from './subscriptionReaper';
 
 /**
  * Custom lambda handler that handles deleting expired subscriptions.
  */
-exports.handler = async (event: any) => {
-    try {
-        const subscriptions = await dbService.getActiveSubscriptions({});
-        const currentTime = new Date();
-        let subTime;
-        const deletions: Promise<{
-            success: boolean,
-            message: string,
-        }>[] = [];
-        // filter out subscriptions without a defined end time.
-        subscriptions.filter(s => s.end).forEach(subscription => {
-            // check if subscription is past its end date (ISO format)
-            // example format of subscriptions: https://www.hl7.org/fhir/subscription-example.json.html
-            subTime = new Date(subscription.end);
-            if (currentTime >= subTime) {
-                // delete the subscription as it has reached its end time
-                deletions.push(dbService.deleteResource({ resourceType: subscription.resourceType, id: subscription.id }));
-            }
-        });
-        await Promise.all(deletions);
-        await sendCfnResponse(event, 'SUCCESS');
-    } catch (e) {
-        await sendCfnResponse(event, 'FAILED', e);
-    }
-};
+exports.handler = reaperHandler;

--- a/src/subscriptions/subscriptionReaper.test.ts
+++ b/src/subscriptions/subscriptionReaper.test.ts
@@ -1,0 +1,90 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import { DynamoDbDataService } from 'fhir-works-on-aws-persistence-ddb';
+import { reaperHandler } from './subscriptionReaper';
+
+jest.mock('fhir-works-on-aws-persistence-ddb');
+describe('subscriptionReaper', () => {
+    test('no subscriptions to delete', async () => {
+        const expectedResponse: {
+            success: boolean;
+            message: string;
+        }[] = [];
+        const subResource = [
+            {
+                resourceType: 'Subscription',
+                id: 'sub1',
+                status: 'requested',
+                end: '2121-01-01T00:00:00Z',
+            },
+        ];
+        const mockGetActiveSubscriptions = jest.fn();
+        DynamoDbDataService.prototype.getActiveSubscriptions = mockGetActiveSubscriptions;
+        mockGetActiveSubscriptions.mockReturnValue(Promise.resolve(subResource));
+        const actualResponse = await reaperHandler({});
+        expect(actualResponse).toEqual(expectedResponse);
+    });
+
+    test('subscriptions that have expired should be deleted', async () => {
+        const message = `Successfully deleted ResourceType: Subscription, Id: sub1, VersionId: 1`;
+        const expectedResponse: {
+            success: boolean;
+            message: string;
+        }[] = [
+            {
+                success: true,
+                message,
+            },
+        ];
+        const subResource = [
+            {
+                resourceType: 'Subscription',
+                id: 'sub1',
+                status: 'requested',
+                end: '2021-01-01T00:00:00Z',
+            },
+            {
+                resourceType: 'Subscription',
+                id: 'sub2',
+                status: 'requested',
+                end: '2121-01-01T00:00:00Z',
+            },
+        ];
+        const mockGetActiveSubscriptions = jest.fn();
+        const mockDeleteResource = jest.fn();
+        DynamoDbDataService.prototype.getActiveSubscriptions = mockGetActiveSubscriptions;
+        DynamoDbDataService.prototype.deleteResource = mockDeleteResource;
+        mockGetActiveSubscriptions.mockReturnValue(Promise.resolve(subResource));
+        mockDeleteResource.mockReturnValue(
+            Promise.resolve([
+                {
+                    success: true,
+                    message,
+                },
+            ]),
+        );
+        const actualResponse = await reaperHandler({});
+        expect(actualResponse).toEqual(expectedResponse);
+    });
+
+    test('subscriptions that have no specified end should not be deleted', async () => {
+        const expectedResponse: {
+            success: boolean;
+            message: string;
+        }[] = [];
+        const subResource = [
+            {
+                resourceType: 'Subscription',
+                id: 'sub1',
+                status: 'requested',
+            },
+        ];
+        const mockGetActiveSubscriptions = jest.fn();
+        DynamoDbDataService.prototype.getActiveSubscriptions = mockGetActiveSubscriptions;
+        mockGetActiveSubscriptions.mockReturnValue(Promise.resolve(subResource));
+        const actualResponse = await reaperHandler({});
+        expect(actualResponse).toEqual(expectedResponse);
+    });
+});

--- a/src/subscriptions/subscriptionReaper.test.ts
+++ b/src/subscriptions/subscriptionReaper.test.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 import { DynamoDbDataService } from 'fhir-works-on-aws-persistence-ddb';
-import { reaperHandler } from './subscriptionReaper';
+import reaperHandler from './subscriptionReaper';
 
 jest.mock('fhir-works-on-aws-persistence-ddb');
 describe('subscriptionReaper', () => {

--- a/src/subscriptions/subscriptionReaper.test.ts
+++ b/src/subscriptions/subscriptionReaper.test.ts
@@ -22,7 +22,7 @@ describe('subscriptionReaper', () => {
         ];
         const mockGetActiveSubscriptions = jest.fn();
         DynamoDbDataService.prototype.getActiveSubscriptions = mockGetActiveSubscriptions;
-        mockGetActiveSubscriptions.mockReturnValue(Promise.resolve(subResource));
+        mockGetActiveSubscriptions.mockResolvedValueOnce(subResource);
         const actualResponse = await reaperHandler({});
         expect(actualResponse).toEqual(expectedResponse);
     });
@@ -56,15 +56,8 @@ describe('subscriptionReaper', () => {
         const mockDeleteResource = jest.fn();
         DynamoDbDataService.prototype.getActiveSubscriptions = mockGetActiveSubscriptions;
         DynamoDbDataService.prototype.deleteResource = mockDeleteResource;
-        mockGetActiveSubscriptions.mockReturnValue(Promise.resolve(subResource));
-        mockDeleteResource.mockReturnValue(
-            Promise.resolve([
-                {
-                    success: true,
-                    message,
-                },
-            ]),
-        );
+        mockGetActiveSubscriptions.mockResolvedValueOnce(subResource);
+        mockDeleteResource.mockResolvedValueOnce([{ success: true, message }]);
         const actualResponse = await reaperHandler({});
         expect(actualResponse).toEqual(expectedResponse);
     });
@@ -83,7 +76,7 @@ describe('subscriptionReaper', () => {
         ];
         const mockGetActiveSubscriptions = jest.fn();
         DynamoDbDataService.prototype.getActiveSubscriptions = mockGetActiveSubscriptions;
-        mockGetActiveSubscriptions.mockReturnValue(Promise.resolve(subResource));
+        mockGetActiveSubscriptions.mockResolvedValueOnce(subResource);
         const actualResponse = await reaperHandler({});
         expect(actualResponse).toEqual(expectedResponse);
     });

--- a/src/subscriptions/subscriptionReaper.ts
+++ b/src/subscriptions/subscriptionReaper.ts
@@ -33,6 +33,7 @@ const reaperHandler = async (event: any) => {
                 // delete the subscription as it has reached its end time
                 return dbServiceWithTenancy.deleteResource({
                     resourceType: subscription.resourceType,
+                    // eslint-disable-next-line no-underscore-dangle
                     id: subscription._id,
                     // _tenantId is an internal field, and getActiveSubscriptions returns the raw Record<string, any>
                     // eslint-disable-next-line no-underscore-dangle

--- a/src/subscriptions/subscriptionReaper.ts
+++ b/src/subscriptions/subscriptionReaper.ts
@@ -18,7 +18,7 @@ const reaperHandler = async (event: any) => {
     // filter out subscriptions without a defined end time.
     // check if subscription is past its end date (ISO format)
     // example format of subscriptions: https://www.hl7.org/fhir/subscription-example.json.html
-    return await Promise.all(
+    return Promise.all(
         subscriptions
             .filter((s: Record<string, any>) => {
                 if (s.end && currentTime >= new Date(s.end)) {
@@ -29,21 +29,15 @@ const reaperHandler = async (event: any) => {
             })
             .map(async (subscription) => {
                 // delete the subscription as it has reached its end time
-                if (enableMultiTenancy) {
-                    return dbServiceWithTenancy.deleteResource({
-                        resourceType: subscription.resourceType,
-                        id: subscription.id,
-                        // _tenantId is an internal field, and getActiveSubscriptions returns the raw Record<string, any>
-                        tenantId: subscription._tenantId
-                    });
-                }
                 return dbServiceWithTenancy.deleteResource({
                     resourceType: subscription.resourceType,
                     id: subscription.id,
+                    // _tenantId is an internal field, and getActiveSubscriptions returns the raw Record<string, any>
+                    // eslint-disable-next-line no-underscore-dangle
+                    tenantId: subscription._tenantId,
                 });
             }),
     );
-
 };
 
 export default reaperHandler;

--- a/src/subscriptions/subscriptionReaper.ts
+++ b/src/subscriptions/subscriptionReaper.ts
@@ -21,7 +21,6 @@ const reaperHandler = async (event: any) => {
     return Promise.all(
         subscriptions
             .filter((s: Record<string, any>) => {
-                // if s.end is undefined, new Date(s.end) will throw an error
                 const date = new Date(s.end);
                 if (date.toString() === 'Invalid Date') {
                     console.log(`Skipping subscription ${s.id} since the end date is not in a valid format: ${s.end}`);

--- a/src/subscriptions/subscriptionReaper.ts
+++ b/src/subscriptions/subscriptionReaper.ts
@@ -21,11 +21,13 @@ const reaperHandler = async (event: any) => {
     return Promise.all(
         subscriptions
             .filter((s: Record<string, any>) => {
-                if (s.end && currentTime >= new Date(s.end)) {
-                    return true;
+                // if s.end is undefined, new Date(s.end) will throw an error
+                const date = new Date(s.end);
+                if (date.toString() === 'Invalid Date') {
+                    console.log(`Skipping subscription ${s.id} since the end date is not in a valid format: ${s.end}`);
+                    return false;
                 }
-                console.log(`Skipping subscription ${s.id} since the end date is not in a valid format: ${s.end}`);
-                return false;
+                return currentTime >= date;
             })
             .map(async (subscription) => {
                 // delete the subscription as it has reached its end time

--- a/src/subscriptions/subscriptionReaper.ts
+++ b/src/subscriptions/subscriptionReaper.ts
@@ -1,0 +1,37 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+import { DynamoDbDataService, DynamoDb } from 'fhir-works-on-aws-persistence-ddb';
+
+const enableMultiTenancy = process.env.ENABLE_MULTI_TENANCY === 'true';
+const dbService = new DynamoDbDataService(DynamoDb, false, {
+    enableMultiTenancy,
+});
+
+const reaperHandler = async (event: any) => {
+    console.log('subscriptionReaper event', event);
+    try {
+        const subscriptions = await dbService.getActiveSubscriptions({});
+        const currentTime = new Date();
+        // filter out subscriptions without a defined end time.
+        // check if subscription is past its end date (ISO format)
+        // example format of subscriptions: https://www.hl7.org/fhir/subscription-example.json.html
+        return await Promise.all(
+            subscriptions
+                .filter((s: Record<string, any>) => s.end && currentTime >= new Date(s.end))
+                .map(async (subscription) => {
+                    // delete the subscription as it has reached its end time
+                    return dbService.deleteResource({
+                        resourceType: subscription.resourceType,
+                        id: subscription.id,
+                    });
+                }),
+        );
+    } catch (e: any) {
+        throw new Error(`Subscription Reaper failed! Error: ${e}`);
+    }
+};
+
+export default reaperHandler;

--- a/src/subscriptions/subscriptionReaper.ts
+++ b/src/subscriptions/subscriptionReaper.ts
@@ -33,7 +33,7 @@ const reaperHandler = async (event: any) => {
                 // delete the subscription as it has reached its end time
                 return dbServiceWithTenancy.deleteResource({
                     resourceType: subscription.resourceType,
-                    id: subscription.id,
+                    id: subscription._id,
                     // _tenantId is an internal field, and getActiveSubscriptions returns the raw Record<string, any>
                     // eslint-disable-next-line no-underscore-dangle
                     tenantId: subscription._tenantId,

--- a/subscriptions/index.ts
+++ b/subscriptions/index.ts
@@ -1,0 +1,38 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import axios from 'axios';
+import { DynamoDbDataService } from 'fhir-works-on-aws-persistence-ddb/src/dataServices/dynamoDbDataService';
+
+const sendCfnResponse = async (event: any, status: 'SUCCESS' | 'FAILED', error?: Error) => {
+    if (error !== undefined) {
+        console.log(error);
+    }
+    const responseBody = JSON.stringify({
+        Status: status,
+        Reason: error?.message,
+        // The value of PhysicalResourceId doesn't really matter in this case.
+        // It just needs to be the same string on all responses to indicate that it is the same resource.
+        PhysicalResourceId: 'subscriptionReaper',
+        StackId: event.StackId,
+        RequestId: event.RequestId,
+        LogicalResourceId: event.LogicalResourceId,
+    });
+    console.log(`Sending response to CFN: ${responseBody}`);
+    await axios.put(event.ResponseURL, responseBody);
+};
+
+/**
+ * Custom lambda handler that handles deleting expired subscriptions.
+ */
+exports.handler = async (event: any) => {
+    console.log(event);
+    try {
+        
+    } catch (e) {
+        await sendCfnResponse(event, 'FAILED', e);
+    }
+};


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added a scheduled lambda that only runs if the flag for Subscriptions is set. Uses persistence.getActiveSubscriptions to filter out active subscriptions and persistence.deleteResource to delete expired ones.

**Testing**
- deployed successfully to an AWS account.
- posted a Subscription resource using Postman
- ran the subscriptionReaper Lambda from the lambda interface on the AWS Console
- verified that expected subscription resources appeared from the getActiveSubscriptions call, and were filtered correctly
- ensured that correct subscription resources were deleted based on end date
- ----
- redeployed on a multi-tenant deployment
- ensured all operations on subscriptions ran as expected with the same method as above


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
