### PR TITLE
fix: codecov actions should not run on feature branches

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -5,7 +5,15 @@
 
 name: Code Coverage Report
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - develop
+      - smart-develop
+  push:
+    branches:
+      - develop
+      - smart-develop
 
 jobs:
   report-test-coverage:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Updating GitHub Action so that the CodeCoverage report does not run on feature branches as it will always fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
