### PR TITLE
test: add tests for tenant isolation of subscriptions

### DIFF
--- a/integration-tests/subscriptions.test.ts
+++ b/integration-tests/subscriptions.test.ts
@@ -43,7 +43,7 @@ if (SUBSCRIPTIONS_ENABLED === 'true') {
             type: 'rest-hook',
             endpoint: SUBSCRIPTIONS_ENDPOINT!,
             payload: 'application/fhir+json',
-            header: [`x-api-key: 9tosTPsmDC9pGQdcwjdwp2tsT4s620uFa38pYc9U`],
+            header: [`x-api-key: ${process.env.SUBSCRIPTIONS_API_KEY}`],
         },
     };
 

--- a/integration-tests/subscriptions.test.ts
+++ b/integration-tests/subscriptions.test.ts
@@ -6,19 +6,15 @@
 
 import * as AWS from 'aws-sdk';
 import { AxiosInstance } from 'axios';
+import { clone } from 'lodash';
 import waitForExpect from 'wait-for-expect';
 import { SubscriptionsHelper } from './SubscriptionsHelper';
 import { getFhirClient } from './utils';
 
 jest.setTimeout(700_000);
 
-const {
-    SUBSCRIPTIONS_ENABLED,
-    SUBSCRIPTIONS_NOTIFICATIONS_TABLE,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    SUBSCRIPTIONS_ENDPOINT,
-    API_AWS_REGION,
-} = process.env;
+const { SUBSCRIPTIONS_ENABLED, SUBSCRIPTIONS_NOTIFICATIONS_TABLE, SUBSCRIPTIONS_ENDPOINT, API_AWS_REGION } =
+    process.env;
 
 if (API_AWS_REGION === undefined) {
     throw new Error('API_AWS_REGION environment variable is not defined');
@@ -31,23 +27,71 @@ test('empty test placeholder', () => {
 });
 
 if (SUBSCRIPTIONS_ENABLED === 'true') {
+    if (!SUBSCRIPTIONS_ENDPOINT) {
+        throw new Error('SUBSCRIPTIONS_ENDPOINT environment variable is not defined');
+    }
+    let client: AxiosInstance;
+    let clientAnotherTenant: AxiosInstance;
+
+    const subscriptionResource = {
+        resourceType: 'Subscription',
+        status: 'requested',
+        // get a time 10 seconds (10000 ms) in the future
+        end: new Date(new Date().getTime() + 10000).toISOString(),
+        reason: 'Monitor Patients with name Smith',
+        criteria: 'Patient?name=Smith',
+        channel: {
+            type: 'rest-hook',
+            endpoint: SUBSCRIPTIONS_ENDPOINT!,
+            payload: 'application/fhir+json',
+            header: [`x-api-key: 9tosTPsmDC9pGQdcwjdwp2tsT4s620uFa38pYc9U`],
+        },
+    };
+
     describe('FHIR Subscriptions', () => {
         let subscriptionsHelper: SubscriptionsHelper;
 
-        beforeAll(() => {
+        beforeAll(async () => {
             if (SUBSCRIPTIONS_NOTIFICATIONS_TABLE === undefined) {
                 throw new Error('SUBSCRIPTIONS_NOTIFICATIONS_TABLE environment variable is not defined');
             }
             subscriptionsHelper = new SubscriptionsHelper(SUBSCRIPTIONS_NOTIFICATIONS_TABLE);
+            client = await getFhirClient();
+            clientAnotherTenant = await getFhirClient({ tenant: 'tenant2' });
         });
 
         test('test', async () => {
             const x = await subscriptionsHelper.getNotifications('/lala');
             console.log(x);
         });
+
+        test('tenant isolation', async () => {
+            // tenant 1 creates a subscription
+            const subResource = clone(subscriptionResource);
+            // make sure the end date isn't caught by the reaper before the test completes
+            subResource.end = new Date(new Date().getTime() + 100000).toISOString();
+            const postResult = await client.post('Subscription', subscriptionResource);
+            expect(postResult.status).toEqual(201);
+            const resourceThatMatchesSubscription = {
+                resourceType: 'Patient',
+                name: [
+                    {
+                        given: ['Smith'],
+                        family: 'Smith',
+                    },
+                ],
+            };
+            // post matching resource on another tenant
+            const postPatientResult = await clientAnotherTenant.post('Patient', resourceThatMatchesSubscription);
+            expect(postPatientResult.status).toEqual(201);
+            // give SLA of 20 seconds for notification to be placed in ddb table
+            await new Promise((r) => setTimeout(r, 20000));
+            // make sure no notification was receieved for first tenant
+            const notifications = await subscriptionsHelper.getNotifications(`/Patient/${postPatientResult.data.id}`);
+            expect(notifications).toEqual([]);
+        });
     });
 
-    let client: AxiosInstance;
     describe('test subscription creation and deletion', () => {
         beforeAll(async () => {
             client = await getFhirClient();
@@ -55,20 +99,6 @@ if (SUBSCRIPTIONS_ENABLED === 'true') {
 
         test('creation of almost expiring subscription should be deleted by reaper', async () => {
             // OPERATE
-            const subscriptionResource = {
-                resourceType: 'Subscription',
-                status: 'requested',
-                // get a time 10 seconds (10000 ms) in the future
-                end: new Date(new Date().getTime() + 10000).toISOString(),
-                reason: 'Monitor Patients with name Smith',
-                criteria: 'Patient?name=Smith',
-                channel: {
-                    type: 'rest-hook',
-                    endpoint: 'https://customer-endpoint.com',
-                    payload: 'application/fhir+json',
-                    header: ['Authorization: Bearer secret-token-abc-123'],
-                },
-            };
             const postSubResult = await client.post('Subscription', subscriptionResource);
             expect(postSubResult.status).toEqual(201); // ensure that the sub resource is created
             const subResourceId = postSubResult.data.id;

--- a/integration-tests/utils.ts
+++ b/integration-tests/utils.ts
@@ -213,6 +213,24 @@ export const randomPatient = () => {
     };
 };
 
+export const randomSubscription = (endpointUUID: string) => {
+    // we checked if environment variable were defined already
+    return {
+        resourceType: 'Subscription',
+        status: 'requested',
+        // get a time 10 minutes (600_000 ms) in the future
+        end: new Date(new Date().getTime() + 600_000).toISOString(),
+        reason: 'Monitor Patients with name Smith',
+        criteria: 'Patient?name=Smith',
+        channel: {
+            type: 'rest-hook',
+            endpoint: `${process.env.SUBSCRIPTIONS_ENDPOINT}/${endpointUUID}`,
+            payload: 'application/fhir+json',
+            header: [`x-api-key: ${process.env.SUBSCRIPTIONS_API_KEY}`],
+        },
+    };
+};
+
 export const randomChainedParamBundle = () => {
     const chance = new Chance();
     return {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/jsonwebtoken": "^8.5.4",
     "@types/node": "^12",
     "@types/sinon": "^9.0.0",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "chance": "^1.1.7",
@@ -77,6 +78,7 @@
     "ts-jest": "^26.4.4",
     "ts-node": "^10.3.0",
     "typescript": "^4.1.3",
+    "uuid": "^8.3.2",
     "wait-for-expect": "^3.0.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2207,6 +2207,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.1.tgz#8f80dd965ad81f3e1bc26d6f5c727e132721ff40"
   integrity sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"


### PR DESCRIPTION
Issue #, if available:
FHIR -764

Description of changes:
Added tests for tenant isolation on subscriptions. The only modifications made to the other tests were to extract common elements such as subscription resource construction.

Tested by running `yarn int-test` and ensuring through the AWS Console that the lambda function ran as expected and the notifications were present in the DDB Table.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [X] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
