### PR TITLE
test: add end to end tests for subscriptions

### DIFF
--- a/integration-tests/bulkExport.test.ts
+++ b/integration-tests/bulkExport.test.ts
@@ -3,15 +3,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 import BulkExportTestHelper, { ExportStatusOutput } from './bulkExportTestHelper';
-import { getFhirClient, getResourcesFromBundleResponse } from './utils';
+import { getFhirClient, getResourcesFromBundleResponse, sleep } from './utils';
 import createGroupMembersBundle from './createGroupMembersBundle.json';
 
 const EIGHT_MINUTES_IN_MS = 8 * 60 * 1000;
 jest.setTimeout(EIGHT_MINUTES_IN_MS);
-
-const sleep = async (milliseconds: number) => {
-    return new Promise((resolve) => setTimeout(resolve, milliseconds));
-};
 
 describe('Bulk Export', () => {
     let bulkExportTestHelper: BulkExportTestHelper;

--- a/integration-tests/subscriptions.test.ts
+++ b/integration-tests/subscriptions.test.ts
@@ -208,7 +208,7 @@ if (SUBSCRIPTIONS_ENABLED === 'true') {
                     expect(notifications).not.toEqual([]);
                     expect(notifications[0].httpMethod).toEqual('POST');
                     expect(notifications[0].body).toBeNull();
-                    // expect(notifications[0].headers!).toContain(SUBSCRIPTIONS_API_KEY);
+                    expect(notifications[0].headers).toHaveProperty('x-api-key', SUBSCRIPTIONS_API_KEY);
                 },
                 60_000,
                 5_000,

--- a/integration-tests/subscriptions.test.ts
+++ b/integration-tests/subscriptions.test.ts
@@ -102,11 +102,11 @@ if (SUBSCRIPTIONS_ENABLED === 'true') {
             await expect(client.post('Subscription', subResource)).rejects.toMatchObject({
                 response: { status: 400 },
             });
-            subResource.channel.type = 'SMS';
+            subResource.channel.type = 'sms';
             await expect(client.post('Subscription', subResource)).rejects.toMatchObject({
                 response: { status: 400 },
             });
-            subResource.channel.type = 'Websocket';
+            subResource.channel.type = 'websocket';
             await expect(client.post('Subscription', subResource)).rejects.toMatchObject({
                 response: { status: 400 },
             });
@@ -143,11 +143,13 @@ if (SUBSCRIPTIONS_ENABLED === 'true') {
                     const notifications = await subscriptionsHelper.getNotifications(
                         `/${uuid}/Patient/${postPatientResult.data.id}`,
                     );
-                    expect(notifications).not.toEqual([]);
                     expect(notifications.length).toEqual(2); // one for create, one for update
                     expect(notifications[0].httpMethod).toEqual('PUT');
                     expect(notifications[0].body).toBeNull();
                     expect(notifications[0].headers).toHaveProperty('x-api-key', SUBSCRIPTIONS_API_KEY);
+                    expect(notifications[1].httpMethod).toEqual('PUT');
+                    expect(notifications[1].body).toBeNull();
+                    expect(notifications[1].headers).toHaveProperty('x-api-key', SUBSCRIPTIONS_API_KEY);
                 },
                 60_000,
                 5_000,
@@ -205,10 +207,13 @@ if (SUBSCRIPTIONS_ENABLED === 'true') {
             await waitForExpect(
                 async () => {
                     const notifications = await subscriptionsHelper.getNotifications(`/${uuid}`);
-                    expect(notifications).not.toEqual([]);
+                    expect(notifications.length).toEqual(2);
                     expect(notifications[0].httpMethod).toEqual('POST');
                     expect(notifications[0].body).toBeNull();
                     expect(notifications[0].headers).toHaveProperty('x-api-key', SUBSCRIPTIONS_API_KEY);
+                    expect(notifications[1].httpMethod).toEqual('POST');
+                    expect(notifications[1].body).toBeNull();
+                    expect(notifications[1].headers).toHaveProperty('x-api-key', SUBSCRIPTIONS_API_KEY);
                 },
                 60_000,
                 5_000,

--- a/integration-tests/utils.ts
+++ b/integration-tests/utils.ts
@@ -14,6 +14,10 @@ import createBundle from './createPatientPractitionerEncounterBundle.json';
 
 const DEFAULT_TENANT_ID = 'tenant1';
 
+export const sleep = async (milliseconds: number) => {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+};
+
 const getAuthParameters: (role: string, tenantId: string) => { PASSWORD: string; USERNAME: string } = (
     role: string,
     tenantId: string,

--- a/integration-tests/utils.ts
+++ b/integration-tests/utils.ts
@@ -213,7 +213,7 @@ export const randomPatient = () => {
     };
 };
 
-export const randomSubscription = (endpointUUID: string) => {
+export const randomSubscription = (endpointUUID: string, emptyNotification = false) => {
     // we checked if environment variable were defined already
     return {
         resourceType: 'Subscription',
@@ -225,7 +225,7 @@ export const randomSubscription = (endpointUUID: string) => {
         channel: {
             type: 'rest-hook',
             endpoint: `${process.env.SUBSCRIPTIONS_ENDPOINT}/${endpointUUID}`,
-            payload: 'application/fhir+json',
+            payload: emptyNotification ? undefined : 'application/fhir+json',
             header: [`x-api-key: ${process.env.SUBSCRIPTIONS_API_KEY}`],
         },
     };


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added end to end tests for empty notification and id notification scenarios. Tested using `yarn int-test` and making sure that the notification table and output looked as expected through the AWS Console.


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [X] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
