### PR TITLE
perf: partial failures for restHook Lambda

### DIFF
--- a/cloudformation/subscriptions.yaml
+++ b/cloudformation/subscriptions.yaml
@@ -32,7 +32,7 @@ Resources:
       KmsMasterKeyId: !Ref SubscriptionsKey
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt RestHookDLQ.Arn
-        maxReceiveCount: 3
+        maxReceiveCount: 2
 
   RestHookDLQ:
     Type: AWS::SQS::Queue

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "fhir-works-on-aws-routing": "6.3.0",
     "fhir-works-on-aws-search-es": "3.9.2",
     "lodash": "^4.17.21",
+    "p-settle": "^4.1.1",
     "serverless-http": "^2.7.0",
     "tslib": "^2.3.1",
     "yargs": "^16.2.0"
@@ -68,7 +69,7 @@
     "jsonwebtoken": "^8.5.1",
     "prettier": "^2.4.1",
     "qs": "^6.10.1",
-    "serverless": "2.64.1",
+    "serverless": "2.68.0",
     "serverless-bundle": "^4.4.0",
     "serverless-offline": "^8.2.0",
     "serverless-step-functions": "^3.1.1",

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -132,7 +132,9 @@ functions:
           startingPosition: LATEST
 
   subscriptionsMatcher:
-    timeout: 60
+    timeout: 20
+    memorySize: !If [isDev, 512, 1024]
+    reservedConcurrency: !If [isDev, 10, 200]
     runtime: nodejs14.x
     description: 'Match ddb events against active Subscriptions and emit notifications'
     role: SubscriptionsMatcherLambdaRole
@@ -230,6 +232,9 @@ functions:
       - sqs:
           arn:
             !GetAtt RestHookQueue.Arn
+          batchSize: 50
+          maximumBatchingWindow: 10
+          functionResponseType: ReportBatchItemFailures
 
 stepFunctions:
   stateMachines:

--- a/src/subscriptions/restHookLambda/allowListUtil.ts
+++ b/src/subscriptions/restHookLambda/allowListUtil.ts
@@ -27,7 +27,6 @@ export async function getAllowListInfo({
     enableMultitenancy: boolean;
 }): Promise<{ [key: string]: AllowListInfo }> {
     const originalAllowList = await getAllowListedSubscriptionEndpoints();
-    logger.debug(originalAllowList);
     if (!enableMultitenancy) {
         return { [SINGLE_TENANT_ALLOW_LIST_KEY]: extractAllowListInfo(originalAllowList) };
     }

--- a/src/subscriptions/restHookLambda/restHook.test.ts
+++ b/src/subscriptions/restHookLambda/restHook.test.ts
@@ -73,7 +73,11 @@ describe('Single tenant: Rest hook notification', () => {
     test('Empty POST notification is sent when channelPayload is null', async () => {
         await expect(
             restHookHandler.sendRestHookNotification(getEvent({ channelPayload: null as any }), allowListPromise),
-        ).resolves.toEqual([{ message: 'POST Successful' }]);
+        ).resolves.toMatchInlineSnapshot(`
+                    Object {
+                      "batchItemFailures": Array [],
+                    }
+                `);
         expect(axios.post).toHaveBeenCalledWith('https://fake-end-point-1', null, {
             headers: { 'header-name-1': ' header-value-1', testKey: 'testValue' },
         });
@@ -85,7 +89,11 @@ describe('Single tenant: Rest hook notification', () => {
                 getEvent({ endpoint: 'https://fake-end-point-2-something' }),
                 allowListPromise,
             ),
-        ).resolves.toEqual([{ message: 'PUT Successful' }]);
+        ).resolves.toMatchInlineSnapshot(`
+                    Object {
+                      "batchItemFailures": Array [],
+                    }
+                `);
         expect(axios.put).toHaveBeenCalledWith('https://fake-end-point-2-something/Patient/1234567', null, {
             headers: { 'header-name-2': ' header-value-2', testKey: 'testValue' },
         });
@@ -100,7 +108,11 @@ describe('Single tenant: Rest hook notification', () => {
                 }),
                 allowListPromise,
             ),
-        ).resolves.toEqual([{ message: 'PUT Successful' }]);
+        ).resolves.toMatchInlineSnapshot(`
+                    Object {
+                      "batchItemFailures": Array [],
+                    }
+                `);
         expect(axios.put).toHaveBeenCalledWith('https://fake-end-point-2-something/Patient/1234567', null, {
             headers: { 'header-name-2': ' header-value-2-something' },
         });
@@ -112,7 +124,11 @@ describe('Single tenant: Rest hook notification', () => {
                 getEvent({ endpoint: 'https://fake-end-point-2-something', channelHeader: ['testKey'] }),
                 allowListPromise,
             ),
-        ).resolves.toEqual([{ message: 'PUT Successful' }]);
+        ).resolves.toMatchInlineSnapshot(`
+                    Object {
+                      "batchItemFailures": Array [],
+                    }
+                `);
         expect(axios.put).toHaveBeenCalledWith('https://fake-end-point-2-something/Patient/1234567', null, {
             headers: { 'header-name-2': ' header-value-2', testKey: '' },
         });
@@ -124,14 +140,27 @@ describe('Single tenant: Rest hook notification', () => {
                 getEvent({ endpoint: 'https://fake-end-point-3' }),
                 allowListPromise,
             ),
-        ).rejects.toThrow(new Error('Endpoint https://fake-end-point-3 is not allow listed.'));
+        ).resolves.toMatchInlineSnapshot(`
+                    Object {
+                      "batchItemFailures": Array [
+                        Object {
+                          "itemIdentifier": "fake-message-id",
+                        },
+                      ],
+                    }
+                `);
     });
 
     test('Error thrown when tenantID is passed in', async () => {
-        await expect(
-            restHookHandler.sendRestHookNotification(getEvent({ tenantId: 'tenant1' }), allowListPromise),
-        ).rejects.toThrow(
-            new Error('This instance has multi-tenancy disabled, but the incoming request has a tenantId'),
-        );
+        await expect(restHookHandler.sendRestHookNotification(getEvent({ tenantId: 'tenant1' }), allowListPromise))
+            .resolves.toMatchInlineSnapshot(`
+                    Object {
+                      "batchItemFailures": Array [
+                        Object {
+                          "itemIdentifier": "fake-message-id",
+                        },
+                      ],
+                    }
+                `);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2019", // Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'.
+    "target": "es2020", // Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'.
     "moduleResolution": "node",
     "strict": true, // // Enable all strict type-checking options.
     "esModuleInterop": true, // Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,7 +1578,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@serverless/cli@^1.5.2":
+"@serverless/cli@^1.5.3":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@serverless/cli/-/cli-1.6.0.tgz#d020f67748401ca209a4fc6407929581810573e2"
   integrity sha512-1Muw/KhS4sZ6+ZrXBdmVY9zAwZh03lF7v1DKtaZ0cmxjqQBwPLoO40rOGXlxR97pyufe2NS6rD/p+ri8NGqeXg==
@@ -1603,7 +1603,7 @@
     node-fetch "^2.6.0"
     shortid "^2.2.14"
 
-"@serverless/components@^3.17.1":
+"@serverless/components@^3.18.1":
   version "3.18.2"
   resolved "https://registry.yarnpkg.com/@serverless/components/-/components-3.18.2.tgz#628d78f96c1ce5f8dc836587f566a404a38d65e7"
   integrity sha512-jQSgd3unajU94R6vjzD0l+PS5lVcky0vrE1DOfb28VPgmaS48+I/niavWR7+SOt0mYjIkUlwBI73a2ZuqeYK6Q==
@@ -1649,7 +1649,7 @@
     ramda "^0.26.1"
     semver "^6.1.1"
 
-"@serverless/dashboard-plugin@^5.5.0":
+"@serverless/dashboard-plugin@^5.5.1":
   version "5.5.4"
   resolved "https://registry.yarnpkg.com/@serverless/dashboard-plugin/-/dashboard-plugin-5.5.4.tgz#2bbe1d5e2e5fa79b0f95422fd5b7558c248ce689"
   integrity sha512-qqZnT/RXhBcWXwYnpF+GMeNvSUi6mnyIqsAHj8+f7jJ7N9qa5Qrb14+dUh78sdgRBG5Peub3m3Mlx1n5V9yHDw==
@@ -1783,7 +1783,7 @@
     uuid "^8.3.2"
     write-file-atomic "^3.0.3"
 
-"@serverless/utils@^5.19.0", "@serverless/utils@^5.20.3":
+"@serverless/utils@^5.20.1", "@serverless/utils@^5.20.3":
   version "5.20.3"
   resolved "https://registry.yarnpkg.com/@serverless/utils/-/utils-5.20.3.tgz#5ab15cf8eceb81934946f2deeee028c6b9b6e270"
   integrity sha512-MG3DQJdto+LaeVY9gh/z0xloAfT0h1Y3Pa4/yYcKe8Dy5HYtSujuav0MvTOH18+s2outjKKJDxTh6tZuyNqFDQ==
@@ -2867,10 +2867,10 @@ aws-sdk@^2.1000.0, aws-sdk@^2.834.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-aws-sdk@^2.1011.0:
-  version "2.1074.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1074.0.tgz#be3283f781b3060cd67d5abef50d1edacefede70"
-  integrity sha512-tD478mkukglutjs+mq5FQmYFzz+l/wddl5u3tTMWTNa+j1eSL+AqaHPFM1rC3O9h98QqpKKzeKbLrPhGDvYaRg==
+aws-sdk@^2.1041.0:
+  version "2.1079.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1079.0.tgz#41ede54aa4ba5ce77d4ffe202f9a1ee7869da2a8"
+  integrity sha512-WHYWiye9f2XYQ33Rj/uVw4VF/Qq/xrB9NDnGlRhgK8Ga7T20+8/iZD5/Z8wICVNZTsfUZ3g6LfkeZ1l+LZhHKw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -3746,7 +3746,7 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-progress-footer@^2.1.1, cli-progress-footer@^2.3.0:
+cli-progress-footer@^2.2.0, cli-progress-footer@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/cli-progress-footer/-/cli-progress-footer-2.3.0.tgz#ef8af382fa8e8c5c649dd3e7667d93b7494d3d3c"
   integrity sha512-xJl+jqvdsE0Gjh5tKoLzZrQS4nPHC+yzeitgq2faAZiHl+/Peuwzoy5Sed6EBkm8JNrPk7W4U3YNVO/uxoqOFg==
@@ -5729,7 +5729,7 @@ filenamify@^4.3.0:
     strip-outer "^1.0.1"
     trim-repeated "^1.0.0"
 
-filesize@^8.0.3:
+filesize@^8.0.6:
   version "8.0.7"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-8.0.7.tgz#695e70d80f4e47012c132d57a059e80c6b580bd8"
   integrity sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==
@@ -8704,7 +8704,7 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.5, node-fetch@^2.6.7:
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.6, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -9063,7 +9063,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0, p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.2:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -9121,6 +9121,11 @@ p-queue@^6.6.2:
     eventemitter3 "^4.0.4"
     p-timeout "^3.2.0"
 
+p-reflect@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-reflect/-/p-reflect-2.1.0.tgz#5d67c7b3c577c4e780b9451fc9129675bd99fe67"
+  integrity sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg==
+
 p-retry@^4.3.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.1.tgz#8fcddd5cdf7a67a0911a9cf2ef0e5df7f602316c"
@@ -9128,6 +9133,14 @@ p-retry@^4.3.0:
   dependencies:
     "@types/retry" "^0.12.0"
     retry "^0.13.1"
+
+p-settle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/p-settle/-/p-settle-4.1.1.tgz#37fbceb2b02c9efc28658fc8d36949922266035f"
+  integrity sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==
+  dependencies:
+    p-limit "^2.2.2"
+    p-reflect "^2.1.0"
 
 p-timeout@^3.1.0, p-timeout@^3.2.0:
   version "3.2.0"
@@ -10583,27 +10596,27 @@ serverless-webpack@^5.3.1:
   optionalDependencies:
     ts-node ">= 8.3.0"
 
-serverless@2.64.1:
-  version "2.64.1"
-  resolved "https://registry.yarnpkg.com/serverless/-/serverless-2.64.1.tgz#708f7000577437f5fec27efd996967d67dc66fb3"
-  integrity sha512-9DErsV4ACg/2UkRoX2EYRkcDyRi3NBld/gexCeVnkmUunadSwnmtSBeVU8spvg+zc61b1vbusTHE4woqcd2gvw==
+serverless@2.68.0:
+  version "2.68.0"
+  resolved "https://registry.yarnpkg.com/serverless/-/serverless-2.68.0.tgz#40158582c9b2806d0c590ac65a84f8d36741bca5"
+  integrity sha512-RFhbwobdTEy/GsisYgLijjamKMpQpPdqD7rKXIFB8Ahfllnk+yFbP0fp/UdOH9qGATik8SISO+0wn5zjrhahxg==
   dependencies:
-    "@serverless/cli" "^1.5.2"
-    "@serverless/components" "^3.17.1"
-    "@serverless/dashboard-plugin" "^5.5.0"
+    "@serverless/cli" "^1.5.3"
+    "@serverless/components" "^3.18.1"
+    "@serverless/dashboard-plugin" "^5.5.1"
     "@serverless/platform-client" "^4.3.0"
-    "@serverless/utils" "^5.19.0"
+    "@serverless/utils" "^5.20.1"
     ajv "^6.12.6"
     ajv-keywords "^3.5.2"
     archiver "^5.3.0"
-    aws-sdk "^2.1011.0"
+    aws-sdk "^2.1041.0"
     bluebird "^3.7.2"
     boxen "^5.1.2"
     cachedir "^2.3.0"
     chalk "^4.1.2"
     child-process-ext "^2.1.1"
-    ci-info "^3.2.0"
-    cli-progress-footer "^2.1.1"
+    ci-info "^3.3.0"
+    cli-progress-footer "^2.2.0"
     d "^1.0.1"
     dayjs "^1.10.7"
     decompress "^4.2.1"
@@ -10612,11 +10625,11 @@ serverless@2.64.1:
     essentials "^1.1.1"
     ext "^1.6.0"
     fastest-levenshtein "^1.0.12"
-    filesize "^8.0.3"
+    filesize "^8.0.6"
     fs-extra "^9.1.0"
     get-stdin "^8.0.0"
     globby "^11.0.4"
-    got "^11.8.2"
+    got "^11.8.3"
     graceful-fs "^4.2.8"
     https-proxy-agent "^5.0.0"
     is-docker "^2.2.1"
@@ -10628,14 +10641,14 @@ serverless@2.64.1:
     memoizee "^0.4.15"
     micromatch "^4.0.4"
     ncjsm "^4.2.0"
-    node-fetch "^2.6.5"
+    node-fetch "^2.6.6"
     object-hash "^2.2.0"
     path2 "^0.1.0"
     process-utils "^4.0.0"
     promise-queue "^2.2.5"
     replaceall "^0.1.6"
     semver "^7.3.5"
-    signal-exit "^3.0.5"
+    signal-exit "^3.0.6"
     strip-ansi "^6.0.1"
     tabtab "^3.0.2"
     tar "^6.1.11"
@@ -10741,7 +10754,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
   integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
 
-signal-exit@^3.0.5:
+signal-exit@^3.0.6:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==


### PR DESCRIPTION
Various performance improvements from working on the load tests.

- The biggest change is switching to  partial batch responses for the restHook Lambda
https://aws.amazon.com/about-aws/whats-new/2021/11/aws-lambda-partial-batch-response-sqs-event-source/
- Enforced a timeout for http requests (otherwise some requests sometimes hung up and timed out the whole Lambda function)
- Added concurrency control for http requests in rest-hook lambda. Mostly so that they get a "fair" timeout value (otherwise they may timeout before even starting for real since creating a bunch of promises in parallel queues all the http requests internally but they may sit in the queue waiting for resources)
- tuned some numbers in `serverless.yaml`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
