### PR TITLE
feat: ISSUE 624 add logging when lambda starts and stops fwoa applica…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,21 @@
  */
 
 import serverless from 'serverless-http';
+import { partial } from 'lodash';
 import { generateServerlessRouter } from 'fhir-works-on-aws-routing';
+import { makeLogger } from 'fhir-works-on-aws-interface';
 import { getFhirConfig, genericResources } from './config';
+
+// setup logging for process start and stops
+const logger = makeLogger({ pid: process.pid, ppid: process.ppid });
+const logProcessEvent = (eventName: string, codeOrSignal: any) => {
+    logger.info('process event raised', { eventName, codeOrSignal });
+};
+logProcessEvent('start', undefined);
+process.on('beforeExit', partial(logProcessEvent, 'beforeExit'));
+process.on('exit', partial(logProcessEvent, 'exit'));
+process.on('SIGTERM', partial(logProcessEvent, 'SIGTERM'));
+process.on('SIGINT', partial(logProcessEvent, 'SIGINT'));
 
 const ensureAsyncInit = async (initPromise: Promise<any>): Promise<void> => {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,15 @@ import { getFhirConfig, genericResources } from './config';
 
 // setup logging for process start and stops
 const logger = makeLogger({ pid: process.pid, ppid: process.ppid });
-const logProcessEvent = (eventName: string, codeOrSignal: any) => {
+const logProcessEvent = async (eventName: string, codeOrSignal: any) => {
     logger.info('process event raised', { eventName, codeOrSignal });
+
+    if (eventName === 'SIGTERM') {
+        // console.* methods are async when the process is piped
+        // so sleep 200ms out of the 300ms allocated to SIGTERM
+        // https://nodejs.org/api/process.html#a-note-on-process-io
+        await new Promise((resolve) => setTimeout(resolve, 200));
+    }
 };
 logProcessEvent('start', undefined);
 process.on('beforeExit', partial(logProcessEvent, 'beforeExit'));


### PR DESCRIPTION
…tion code in the fhirServer lambda

Issue #, if available:
https://github.com/awslabs/fhir-works-on-aws-deployment/issues/624

Description of changes:
Added logging for when the fhirServer lambda process is started or stopped. I was able to test by running `serverless offline start --printOutput --allowCache --logLevel info`

I was able to assert the following:
* the 1st web request processed writes `start` entry
* subsequent requests do not log a process event
* kill -15 $pid writes `SIGTERM` entry & `exit` entry
* kill -2 $pid writes `SIGINT` entry & `exit` entry

Checklist:
* [X ] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
