### PR TITLE
feat: add implementation guides support via cdk

### DIFF
--- a/bin/cdk-infra.ts
+++ b/bin/cdk-infra.ts
@@ -10,6 +10,7 @@ import FhirWorksStack from '../lib/cdk-infra-stack';
 const app = new cdk.App();
 
 const allowedLogLevels = ['error', 'info', 'debug', 'warn'];
+const allowedFHIRVersions = ['4.0.1', '3.0.1']
 
 const region: string = app.node.tryGetContext('region') || 'us-west-2';
 const stage: string = app.node.tryGetContext('stage') || 'dev';
@@ -17,9 +18,17 @@ const enableMultiTenancy: boolean = app.node.tryGetContext('enableMultiTenancy')
 const enableSubscriptions: boolean = app.node.tryGetContext('enableSubscriptions') || false;
 const oauthRedirect: string = app.node.tryGetContext('oauthRedirect') || 'http://localhost';
 const useHapiValidator: boolean = app.node.tryGetContext('useHapiValidator') || false;
-let logLevel: string = app.node.tryGetContext('logLevel') || 'error';
 const enableESHardDelete: boolean = app.node.tryGetContext('enableESHardDelete') || false;
 const enableBackup: boolean = app.node.tryGetContext('enableBackup') || false;
+let logLevel: string = app.node.tryGetContext('logLevel') || 'error';
+let fhirVersion: string = app.node.tryGetContext('fhirVersion') || '4.0.1';
+
+if (useHapiValidator) {
+    if (!allowedFHIRVersions.includes(fhirVersion)) {
+        console.log(`invalid FHIR Version specified: ${fhirVersion}`);
+        fhirVersion = '4.0.1';
+    }
+}
 
 if (!allowedLogLevels.includes(logLevel)) {
     console.log(`invalid log level specified: ${logLevel}`);
@@ -43,6 +52,7 @@ const stack = new FhirWorksStack(app, `fhir-service-${stage}`, {
     logLevel,
     oauthRedirect,
     enableBackup,
+    fhirVersion,
     description:
         '(SO0128) - Solution - Primary Template - This template creates all the necessary resources to deploy FHIR Works on AWS; a framework to deploy a FHIR server on AWS.',
 });

--- a/bin/cdk-infra.ts
+++ b/bin/cdk-infra.ts
@@ -25,8 +25,7 @@ let fhirVersion: string = app.node.tryGetContext('fhirVersion') || '4.0.1';
 
 if (useHapiValidator) {
     if (!allowedFHIRVersions.includes(fhirVersion)) {
-        console.log(`invalid FHIR Version specified: ${fhirVersion}`);
-        fhirVersion = '4.0.1';
+        throw new Error(`invalid FHIR Version specified: ${fhirVersion}`);
     }
 }
 

--- a/bin/cdk-infra.ts
+++ b/bin/cdk-infra.ts
@@ -10,7 +10,7 @@ import FhirWorksStack from '../lib/cdk-infra-stack';
 const app = new cdk.App();
 
 const allowedLogLevels = ['error', 'info', 'debug', 'warn'];
-const allowedFHIRVersions = ['4.0.1', '3.0.1']
+const allowedFHIRVersions = ['4.0.1', '3.0.1'];
 
 const region: string = app.node.tryGetContext('region') || 'us-west-2';
 const stage: string = app.node.tryGetContext('stage') || 'dev';
@@ -21,7 +21,7 @@ const useHapiValidator: boolean = app.node.tryGetContext('useHapiValidator') || 
 const enableESHardDelete: boolean = app.node.tryGetContext('enableESHardDelete') || false;
 const enableBackup: boolean = app.node.tryGetContext('enableBackup') || false;
 let logLevel: string = app.node.tryGetContext('logLevel') || 'error';
-let fhirVersion: string = app.node.tryGetContext('fhirVersion') || '4.0.1';
+const fhirVersion: string = app.node.tryGetContext('fhirVersion') || '4.0.1';
 
 if (useHapiValidator) {
     if (!allowedFHIRVersions.includes(fhirVersion)) {

--- a/cdk.json
+++ b/cdk.json
@@ -37,6 +37,7 @@
     "useHapiValidator": false,
     "logLevel": "error",
     "enableESHardDelete": false,
-    "enableBackup": false
+    "enableBackup": false,
+    "fhirVersion": "4.0.1"
   }
 }

--- a/lib/cdk-infra-stack.ts
+++ b/lib/cdk-infra-stack.ts
@@ -49,6 +49,7 @@ export interface FhirWorksStackProps extends StackProps {
 
 export default class FhirWorksStack extends Stack {
     javaHapiValidator: JavaHapiValidator | undefined;
+
     constructor(scope: Construct, id: string, props?: FhirWorksStackProps) {
         super(scope, id, props);
 
@@ -528,9 +529,7 @@ export default class FhirWorksStack extends Stack {
                     afterBundling(inputDir, outputDir) {
                         // copy all the necessary files for the lambda into the bundle
                         // this allows the validators to be constructed with the compiled implementation guides
-                        return [
-                            `cp -r ${inputDir}\\compiledImplementationGuides ${outputDir}`,
-                        ];
+                        return [`cp -r ${inputDir}\\compiledImplementationGuides ${outputDir}`];
                     },
                 },
             },
@@ -543,7 +542,9 @@ export default class FhirWorksStack extends Stack {
                 EXPORT_STATE_MACHINE_ARN: bulkExportStateMachine.bulkExportStateMachine.stateMachineArn,
                 PATIENT_COMPARTMENT_V3,
                 PATIENT_COMPARTMENT_V4,
-                VALIDATOR_LAMBDA_ALIAS: props!.useHapiValidator ? this.javaHapiValidator!.hapiValidatorLambda.functionArn : '',
+                VALIDATOR_LAMBDA_ALIAS: props!.useHapiValidator
+                    ? this.javaHapiValidator!.hapiValidatorLambda.functionArn
+                    : '',
             },
             role: new Role(this, 'fhirServerLambdaRole', {
                 assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
@@ -637,15 +638,13 @@ export default class FhirWorksStack extends Stack {
             tracing: Tracing.ACTIVE,
         });
         if (props!.useHapiValidator) {
-          fhirServerLambda.role?.addToPrincipalPolicy(new PolicyStatement({
-            effect: Effect.ALLOW,
-            actions: [
-              'lambda:InvokeFunction',
-            ],
-            resources: [
-              this.javaHapiValidator!.hapiValidatorLambda.functionArn,
-            ]
-          }));
+            fhirServerLambda.role?.addToPrincipalPolicy(
+                new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    actions: ['lambda:InvokeFunction'],
+                    resources: [this.javaHapiValidator!.hapiValidatorLambda.functionArn],
+                }),
+            );
         }
 
         const apiGatewayApiKey = apiGatewayRestApi.addApiKey('developerApiKey', {

--- a/lib/cdk-infra-stack.ts
+++ b/lib/cdk-infra-stack.ts
@@ -527,7 +527,7 @@ export default class FhirWorksStack extends Stack {
                     },
                     afterBundling(inputDir, outputDir) {
                         // copy all the necessary files for the lambda into the bundle
-                        // this allows the lambda functions for bulk export to have access to these files within the lambda instance
+                        // this allows the validators to be constructed with the compiled implementation guides
                         return [
                             `cp -r ${inputDir}\\compiledImplementationGuides ${outputDir}`,
                         ];
@@ -543,8 +543,7 @@ export default class FhirWorksStack extends Stack {
                 EXPORT_STATE_MACHINE_ARN: bulkExportStateMachine.bulkExportStateMachine.stateMachineArn,
                 PATIENT_COMPARTMENT_V3,
                 PATIENT_COMPARTMENT_V4,
-                // config.ts only checks if the arn is present or equal to [object Object]
-                VALIDATOR_LAMBDA_ALIAS: props!.useHapiValidator ? this.javaHapiValidator!.hapiValidatorLambda.functionArn : '[object Object]',
+                VALIDATOR_LAMBDA_ALIAS: props!.useHapiValidator ? this.javaHapiValidator!.hapiValidatorLambda.functionArn : '',
             },
             role: new Role(this, 'fhirServerLambdaRole', {
                 assumedBy: new ServicePrincipal('lambda.amazonaws.com'),

--- a/lib/javaHapiValidator.ts
+++ b/lib/javaHapiValidator.ts
@@ -11,12 +11,11 @@ export interface JavaHapiValidatorProps extends StackProps {
 }
 
 export default class JavaHapiValidator extends Stack {
-    
     hapiValidatorLambda: Function;
 
     constructor(scope: Construct, id: string, props: JavaHapiValidatorProps) {
         super(scope, id, props);
-        
+
         this.hapiValidatorLambda = new Function(scope, 'validator', {
             handler: 'software.amazon.fwoa.Handler',
             timeout: Duration.seconds(25),
@@ -25,16 +24,15 @@ export default class JavaHapiValidator extends Stack {
                 provisionedConcurrentExecutions: 5,
             },
             logRetention: RetentionDays.TEN_YEARS,
-            code: Code.fromAsset(path.resolve(__dirname, `../javaHapiValidatorLambda/target/fwoa-hapi-validator-dev.jar`), {
-                
-            }),
+            code: Code.fromAsset(
+                path.resolve(__dirname, `../javaHapiValidatorLambda/target/fwoa-hapi-validator-dev.jar`),
+                {},
+            ),
             runtime: Runtime.JAVA_11,
             tracing: Tracing.ACTIVE,
             environment: {
-                'FHIR_VERSION': props.fhirVersion,
-            }
+                FHIR_VERSION: props.fhirVersion,
+            },
         });
-
-
     }
 }

--- a/lib/javaHapiValidator.ts
+++ b/lib/javaHapiValidator.ts
@@ -1,0 +1,40 @@
+import { Duration, Stack, StackProps } from 'aws-cdk-lib';
+import { Code, Function, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Construct } from 'constructs';
+import * as path from 'path';
+
+export interface JavaHapiValidatorProps extends StackProps {
+    stage: string;
+    fhirVersion: string;
+    region: string;
+}
+
+export default class JavaHapiValidator extends Stack {
+    
+    hapiValidatorLambda: Function;
+
+    constructor(scope: Construct, id: string, props: JavaHapiValidatorProps) {
+        super(scope, id, props);
+        
+        this.hapiValidatorLambda = new Function(scope, 'validator', {
+            handler: 'software.amazon.fwoa.Handler',
+            timeout: Duration.seconds(25),
+            memorySize: 2048,
+            currentVersionOptions: {
+                provisionedConcurrentExecutions: 5,
+            },
+            logRetention: RetentionDays.TEN_YEARS,
+            code: Code.fromAsset(path.resolve(__dirname, `../javaHapiValidatorLambda/target/fwoa-hapi-validator-dev.jar`), {
+                
+            }),
+            runtime: Runtime.JAVA_11,
+            tracing: Tracing.ACTIVE,
+            environment: {
+                'FHIR_VERSION': props.fhirVersion,
+            }
+        });
+
+
+    }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,7 @@ const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb, undefined, und
 
 // Configure the input validators. Validators run in the order that they appear on the array. Use an empty array to disable input validation.
 const validators: Validator[] = [];
-if (process.env.VALIDATOR_LAMBDA_ALIAS && process.env.VALIDATOR_LAMBDA_ALIAS !== '[object Object]') {
+if (process.env.VALIDATOR_LAMBDA_ALIAS && process.env.VALIDATOR_LAMBDA_ALIAS !== '[object Object]' && process.env.VALIDATOR_LAMBDA_ALIAS !== '') {
     // The HAPI FHIR Validator must be deployed separately. It is the recommended choice when using implementation guides.
     validators.push(new HapiFhirLambdaValidator(process.env.VALIDATOR_LAMBDA_ALIAS));
 } else if (process.env.OFFLINE_VALIDATOR_LAMBDA_ALIAS) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,11 @@ const dynamoDbBundleService = new DynamoDbBundleService(DynamoDb, undefined, und
 
 // Configure the input validators. Validators run in the order that they appear on the array. Use an empty array to disable input validation.
 const validators: Validator[] = [];
-if (process.env.VALIDATOR_LAMBDA_ALIAS && process.env.VALIDATOR_LAMBDA_ALIAS !== '[object Object]' && process.env.VALIDATOR_LAMBDA_ALIAS !== '') {
+if (
+    process.env.VALIDATOR_LAMBDA_ALIAS &&
+    process.env.VALIDATOR_LAMBDA_ALIAS !== '[object Object]' &&
+    process.env.VALIDATOR_LAMBDA_ALIAS !== ''
+) {
     // The HAPI FHIR Validator must be deployed separately. It is the recommended choice when using implementation guides.
     validators.push(new HapiFhirLambdaValidator(process.env.VALIDATOR_LAMBDA_ALIAS));
 } else if (process.env.OFFLINE_VALIDATOR_LAMBDA_ALIAS) {

--- a/src/implementationGuides/loadCompiledIGs.ts
+++ b/src/implementationGuides/loadCompiledIGs.ts
@@ -20,7 +20,7 @@ export const loadImplementationGuides = (
     implementationGuidesPath?: PathLike,
 ): any[] | undefined => {
     const resolvedImplementationGuidesPath =
-        implementationGuidesPath ?? path.join(__dirname, '..', COMPILED_IGS_DIRECTORY);
+        implementationGuidesPath ?? path.join(__dirname, COMPILED_IGS_DIRECTORY);
 
     const igsPath = path.join(resolvedImplementationGuidesPath.toString(), `${moduleName}.json`);
 

--- a/src/implementationGuides/loadCompiledIGs.ts
+++ b/src/implementationGuides/loadCompiledIGs.ts
@@ -19,8 +19,7 @@ export const loadImplementationGuides = (
     moduleName: string,
     implementationGuidesPath?: PathLike,
 ): any[] | undefined => {
-    const resolvedImplementationGuidesPath =
-        implementationGuidesPath ?? path.join(__dirname, COMPILED_IGS_DIRECTORY);
+    const resolvedImplementationGuidesPath = implementationGuidesPath ?? path.join(__dirname, COMPILED_IGS_DIRECTORY);
 
     const igsPath = path.join(resolvedImplementationGuidesPath.toString(), `${moduleName}.json`);
 

--- a/test/cdk-infra.test.ts
+++ b/test/cdk-infra.test.ts
@@ -7,7 +7,7 @@ test('Resources created', () => {
     // WHEN
     const stack = new FhirWorksStack(app, 'MyTestStack');
     // THEN
-    //eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const template = Template.fromStack(stack);
 
     //   template.hasResourceProperties('AWS::SQS::Queue', {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added a context parameter to specify fhir version and made it part of the main stack, so we don't have to go into the `javaHapiValidatorLambda` directory to deploy. (will document changes in the documentation task)

I tested this by running the integration test for implementation guides and ensuring that all tests passed.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [X] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
