### PR TITLE
fix: ISSUE-639 enabled reuse of https sockets in the aws-sdk

### DIFF
--- a/auditLogMover/serverless.yaml
+++ b/auditLogMover/serverless.yaml
@@ -25,6 +25,7 @@ provider:
     CLOUDWATCH_EXECUTION_LOG_GROUP: !ImportValue CloudwatchAccessLogGroup-${opt:stage, self:provider.stage}
     AUDIT_LOGS_BUCKET: !Ref AuditLogsBucket
     STAGE: ${opt:stage, self:provider.stage}
+    AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
   variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._@'\",\\-\\/\\(\\)]+?)}" # Use this for allowing CloudFormation Pseudo-Parameters in your serverless.yml
   iamRoleStatements:
     - Action:

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -67,6 +67,7 @@ provider:
     ENABLE_MULTI_TENANCY: !Ref EnableMultiTenancy
     ENABLE_SUBSCRIPTIONS: !Ref EnableSubscriptions
     LOG_LEVEL: '${self:custom.logLevel}'
+    AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
   apiKeys:
     - name: 'developer-key-${self:custom.stage}' # Full name must be known at package-time
       description: Key for developer to access the FHIR Api


### PR DESCRIPTION
Issue #, if available:
ISSUE-639
Description of changes:
Enabled the reuse of https sockets in all lambdas in the aws-sdk.

Checklist:

* [X] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
