### PR TITLE
fix: dependencies mismatch for node in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,16 +53,16 @@ function install_dependencies(){
         sudo $PKG_MANAGER update
         sudo $PKG_MANAGER upgrade
 
-        #Yarn depends on node version >= 12.0.0
+        #Yarn depends on node version >= 14.0.0
         if [ "$basepkg" == "apt-get" ]; then
-            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
             sudo apt-get install nodejs -y
         elif [ "$basepkg" == "yum" ]; then
             if [[ $KERNEL_RELEASE =~ amzn2.x86_64 ]]; then
-                curl -sL https://rpm.nodesource.com/setup_12.x | bash -
+                curl -sL https://rpm.nodesource.com/setup_14.x | bash -
                 yum install nodejs -y
             else
-                yum install nodejs12 -y
+                yum install nodejs14 -y
             fi
         fi
 


### PR DESCRIPTION
Issue #, if available: #645

Description of changes:
updated the install.sh to match the dependencies for node stated in package.json (like 132)

Checklist:

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
