### PR TITLE
fix: bundle lambdas in script instead of command line

### DIFF
--- a/lib/cdk-infra-stack.ts
+++ b/lib/cdk-infra-stack.ts
@@ -381,12 +381,10 @@ export default class FhirWorksStack extends Stack {
                         // copy all the necessary files for the lambda into the bundle
                         // this allows the lambda functions for bulk export to have access to these files within the lambda instance
                         return [
-                            `dir ${outputDir}\\bulkExport || mkdir -p ${outputDir}\\bulkExport\\glueScripts`,
-                            `dir ${outputDir}\\bulkExport\\schema || mkdir ${outputDir}\\bulkExport\\schema`,
-                            `cp ${inputDir}\\bulkExport\\glueScripts\\export-script.py ${outputDir}\\bulkExport\\glueScripts\\export-script.py`,
-                            `cp ${inputDir}\\bulkExport\\schema\\transitiveReferenceParams.json ${outputDir}\\bulkExport\\schema\\transitiveReferenceParams.json`,
-                            `cp ${inputDir}\\bulkExport\\schema\\${PATIENT_COMPARTMENT_V3} ${outputDir}\\bulkExport\\schema\\${PATIENT_COMPARTMENT_V3}`,
-                            `cp ${inputDir}\\bulkExport\\schema\\${PATIENT_COMPARTMENT_V4} ${outputDir}\\bulkExport\\schema\\${PATIENT_COMPARTMENT_V4}`,
+                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport\\glueScripts\\export-script.py`,
+                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport\\schema\\transitiveReferenceParams.json`,
+                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport\\schema\\${PATIENT_COMPARTMENT_V3}`,
+                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport\\schema\\${PATIENT_COMPARTMENT_V4}`,
                         ];
                     },
                 },
@@ -545,7 +543,7 @@ export default class FhirWorksStack extends Stack {
                     afterBundling(inputDir, outputDir) {
                         // copy all the necessary files for the lambda into the bundle
                         // this allows the validators to be constructed with the compiled implementation guides
-                        return [`cp -r ${inputDir}\\compiledImplementationGuides ${outputDir}`];
+                        return [`node scripts/build_lambda.js ${inputDir}\\compiledImplementationGuides ${outputDir}\\compiledImplementationGuides none true`];
                     },
                 },
             },

--- a/lib/cdk-infra-stack.ts
+++ b/lib/cdk-infra-stack.ts
@@ -22,7 +22,15 @@ import {
 } from 'aws-cdk-lib/aws-apigateway';
 import { AttributeType, BillingMode, StreamViewType, Table, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
-import { AnyPrincipal, Effect, PolicyDocument, PolicyStatement, Role, ServicePrincipal, StarPrincipal } from 'aws-cdk-lib/aws-iam';
+import {
+    AnyPrincipal,
+    Effect,
+    PolicyDocument,
+    PolicyStatement,
+    Role,
+    ServicePrincipal,
+    StarPrincipal,
+} from 'aws-cdk-lib/aws-iam';
 import { Alias } from 'aws-cdk-lib/aws-kms';
 import { Runtime, StartingPosition, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { DynamoEventSource, SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';

--- a/lib/cdk-infra-stack.ts
+++ b/lib/cdk-infra-stack.ts
@@ -543,7 +543,9 @@ export default class FhirWorksStack extends Stack {
                     afterBundling(inputDir, outputDir) {
                         // copy all the necessary files for the lambda into the bundle
                         // this allows the validators to be constructed with the compiled implementation guides
-                        return [`node scripts/build_lambda.js ${inputDir}\\compiledImplementationGuides ${outputDir}\\compiledImplementationGuides none true`];
+                        return [
+                            `node scripts/build_lambda.js ${inputDir}\\compiledImplementationGuides ${outputDir}\\compiledImplementationGuides none true`,
+                        ];
                     },
                 },
             },

--- a/lib/subscriptions.ts
+++ b/lib/subscriptions.ts
@@ -77,7 +77,7 @@ export default class SubscriptionsResources {
         this.restHookDLQ.addToResourcePolicy(
             new PolicyStatement({
                 effect: Effect.DENY,
-                actions: ['SQS:*'],
+                actions: ['sqs:*'],
                 resources: [this.restHookDLQ.queueArn],
                 principals: [new StarPrincipal()],
                 conditions: {
@@ -91,12 +91,12 @@ export default class SubscriptionsResources {
         this.restHookQueue.addToResourcePolicy(
             new PolicyStatement({
                 effect: Effect.DENY,
-                actions: ['SQS:*'],
+                actions: ['sqs:*'],
                 resources: [this.restHookQueue.queueArn],
                 principals: [new StarPrincipal()],
                 conditions: {
                     Bool: {
-                        'aws:SecureTransport': 'false',
+                        'aws:SecureTransport': false,
                     },
                 },
             }),
@@ -104,7 +104,7 @@ export default class SubscriptionsResources {
         this.restHookQueue.addToResourcePolicy(
             new PolicyStatement({
                 effect: Effect.ALLOW,
-                actions: ['SQS:SendMessage'],
+                actions: ['sqs:SendMessage'],
                 resources: [this.restHookQueue.queueArn],
                 principals: [new ServicePrincipal('sns.amazonaws.com')],
                 conditions: {
@@ -136,7 +136,7 @@ export default class SubscriptionsResources {
                         }),
                         new PolicyStatement({
                             effect: Effect.ALLOW,
-                            actions: ['xray:PutTraceSegments', 'scray:PutTelemetryRecords'],
+                            actions: ['xray:PutTraceSegments', 'xray:PutTelemetryRecords'],
                             resources: ['*'],
                         }),
                         new PolicyStatement({

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/chance": "^1.1.1",
     "@types/express": "^4.17.2",
+    "@types/fs-extra": "^9.0.13",
     "@types/jest": "^26.0.19",
     "@types/jsonwebtoken": "^8.5.4",
     "@types/lodash": "^4.14.182",
@@ -87,6 +88,7 @@
     "fhir-works-on-aws-persistence-ddb": "3.11.0",
     "fhir-works-on-aws-routing": "6.5.0",
     "fhir-works-on-aws-search-es": "3.12.0",
+    "fs-extra": "^10.1.0",
     "lodash": "^4.17.21",
     "p-settle": "^4.1.1",
     "path": "^0.12.7",

--- a/scripts/build_lambda.js
+++ b/scripts/build_lambda.js
@@ -1,11 +1,26 @@
-path = require('path');
-esbuild = require('esbuild');
+var fs = require('fs');
+var fse = require('fs-extra');
+var path = require('path');
 
-esbuild.build({
-    entryPoints: [path.join(__dirname, '../../src/index.ts')],
-    bundle: true,
-    platform: 'node',
-    target: 'node14',
-    external: ['aws-sdk'],
-    outfile: path.join(__dirname, '../index.js'),
-}).catch(() => process.exit(1));
+// expected usage: `node build_lambda.js <path> <path> <pathToFile> <fileName>`
+// for use with NodeJsFunction command hooks to add files to Lambda functions,
+// so <path> <path> will usually be the inputDir and outputDir variables, respectively
+var inputDir = process.argv[2];
+var outputDir = process.argv[3];
+var fileToMove = process.argv[4];
+var isDirectory = process.argv.length > 5 ? true : false;
+
+function ensureDirectoryExistence(filePath) {
+    var dirname = path.dirname(filePath);
+    if (fs.existsSync(dirname)) {
+        return true;
+    }
+    fs.mkdirSync(dirname, { recursive: true });
+}
+
+if (isDirectory) {
+    fse.copySync(inputDir, outputDir);
+} else {
+    ensureDirectoryExistence(`${outputDir}\\${fileToMove}`);
+    fs.copyFileSync(`${inputDir}\\${fileToMove}`, `${outputDir}\\${fileToMove}`);
+}

--- a/src/subscriptions/restHookLambda/restHook.ts
+++ b/src/subscriptions/restHookLambda/restHook.ts
@@ -66,9 +66,9 @@ export default class RestHookHandler {
         event: SQSEvent,
         allowListPromise: Promise<{ [key: string]: AllowListInfo }>,
     ): Promise<SQSBatchResponse> {
-        console.log(allowListPromise);
+        logger.debug(allowListPromise);
         const allowList = await allowListPromise;
-        console.log(allowList);
+        logger.debug(allowList);
         const messages = event.Records.map((record: any): SubscriptionNotification => {
             const body = JSON.parse(record.body);
             return JSON.parse(body.Message);

--- a/src/subscriptions/restHookLambda/restHook.ts
+++ b/src/subscriptions/restHookLambda/restHook.ts
@@ -67,8 +67,10 @@ export default class RestHookHandler {
         event: SQSEvent,
         allowListPromise: Promise<{ [key: string]: AllowListInfo }>,
     ): Promise<SQSBatchResponse> {
-        await ensureAsyncInit(allowListPromise);
+        //await ensureAsyncInit(allowListPromise);
+        console.log(allowListPromise);
         const allowList = await allowListPromise;
+        console.log(allowList);
         const messages = event.Records.map((record: any): SubscriptionNotification => {
             const body = JSON.parse(record.body);
             return JSON.parse(body.Message);

--- a/src/subscriptions/restHookLambda/restHook.ts
+++ b/src/subscriptions/restHookLambda/restHook.ts
@@ -5,7 +5,6 @@ import { SubscriptionNotification } from 'fhir-works-on-aws-search-es';
 import { metricScope, Unit } from 'aws-embedded-metrics';
 import https from 'https';
 import pSettle from 'p-settle';
-import { ensureAsyncInit } from '../../index';
 import { AllowListInfo, getAllowListHeaders } from './allowListUtil';
 
 const logger = makeLogger({ component: 'subscriptions' });
@@ -67,7 +66,6 @@ export default class RestHookHandler {
         event: SQSEvent,
         allowListPromise: Promise<{ [key: string]: AllowListInfo }>,
     ): Promise<SQSBatchResponse> {
-        //await ensureAsyncInit(allowListPromise);
         console.log(allowListPromise);
         const allowList = await allowListPromise;
         console.log(allowList);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2829,6 +2829,13 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -2919,7 +2926,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=13.7.0":
+"@types/node@*":
   version "17.0.38"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.38.tgz#f8bb07c371ccb1903f3752872c89f44006132947"
   integrity sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==
@@ -2928,6 +2935,11 @@
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
   integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
+
+"@types/node@^17.0.33":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
+  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -3594,7 +3606,7 @@ async-hook-jl@^1.7.6:
   dependencies:
     stack-chain "^1.3.7"
 
-async@^2.6.1, async@^2.6.2, async@^3.1.0, async@^3.2.0, async@^3.2.2:
+async@^2.6.1, async@^2.6.2, async@^3.2.2, async@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
   integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
@@ -9387,10 +9399,10 @@ mkdirp@^0.5.1, mkdirp@^0.5.3:
   dependencies:
     minimist "^1.2.6"
 
-moment@^2.14.1, moment@^2.29.1:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
-  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
+moment@2.29.2, moment@^2.14.1, moment@^2.29.1:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
 moo@^0.5.0:
   version "0.5.1"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Created a script to move files as needed instead of using command line hooks. This resolves the failing action here https://github.com/awslabs/fhir-works-on-aws-deployment/actions/runs/2678017744

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [X] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
