### PR TITLE
fix: update paths and include linux esbuild

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,0 @@
-supportedArchitectures:
-  os:
-    - "linux"
-    - "win64"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,4 @@
+supportedArchitectures:
+  os:
+    - "linux"
+    - "win64"

--- a/lib/cdk-infra-stack.ts
+++ b/lib/cdk-infra-stack.ts
@@ -389,10 +389,10 @@ export default class FhirWorksStack extends Stack {
                         // copy all the necessary files for the lambda into the bundle
                         // this allows the lambda functions for bulk export to have access to these files within the lambda instance
                         return [
-                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport\\glueScripts\\export-script.py`,
-                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport\\schema\\transitiveReferenceParams.json`,
-                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport\\schema\\${PATIENT_COMPARTMENT_V3}`,
-                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport\\schema\\${PATIENT_COMPARTMENT_V4}`,
+                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport/glueScripts/export-script.py`,
+                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport/schema/transitiveReferenceParams.json`,
+                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport/schema/${PATIENT_COMPARTMENT_V3}`,
+                            `node scripts/build_lambda.js ${inputDir} ${outputDir} bulkExport/schema/${PATIENT_COMPARTMENT_V4}`,
                         ];
                     },
                 },
@@ -552,7 +552,7 @@ export default class FhirWorksStack extends Stack {
                         // copy all the necessary files for the lambda into the bundle
                         // this allows the validators to be constructed with the compiled implementation guides
                         return [
-                            `node scripts/build_lambda.js ${inputDir}\\compiledImplementationGuides ${outputDir}\\compiledImplementationGuides none true`,
+                            `node scripts/build_lambda.js ${inputDir}/compiledImplementationGuides ${outputDir}/compiledImplementationGuides none true`,
                         ];
                     },
                 },

--- a/scripts/build_lambda.js
+++ b/scripts/build_lambda.js
@@ -21,6 +21,6 @@ function ensureDirectoryExistence(filePath) {
 if (isDirectory) {
     fse.copySync(inputDir, outputDir);
 } else {
-    ensureDirectoryExistence(`${outputDir}\\${fileToMove}`);
-    fs.copyFileSync(`${inputDir}\\${fileToMove}`, `${outputDir}\\${fileToMove}`);
+    ensureDirectoryExistence(`${outputDir}/${fileToMove}`);
+    fs.copyFileSync(`${inputDir}/${fileToMove}`, `${outputDir}/${fileToMove}`);
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Updating paths to use forward slashes instead of backslashes as per https://stackoverflow.com/a/38428899. In addition, created a .yarnrc.yml to allow for multiple versions of esbuild based on platform.

Tested using WSL.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
