### PR TITLE
fix: compiled IGs should be copied to src directory

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -34,7 +34,7 @@ custom:
       - from: 'bulkExport/schema/${self:custom.patientCompartmentFileV4}'
         to: './bulkExport/schema/${self:custom.patientCompartmentFileV4}'
       - from: 'compiledImplementationGuides'
-        to: './compiledImplementationGuides'
+        to: './src/compiledImplementationGuides'
 
 provider:
   name: aws


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This is a simple change of paths to address an issue with serverless using a parent level directory for compiled IGs. This is incompatible with the structure of CDK's Lambda functions. This will not affect any functionality, just updates the location of the folder.
Tested using the implementation-guides integration test.
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [X] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
