### PR TITLE
fix: update inferno test selectors

### DIFF
--- a/.github/workflows/deploy-smart.yaml
+++ b/.github/workflows/deploy-smart.yaml
@@ -191,6 +191,10 @@ jobs:
           sed -i -e "s#TOKEN_ENDPOINT#$TOKEN_ENDPOINT#g" fhir-works.json
           sed -i -e "s#AUTH_USERNAME#$AUTH_USERNAME#g" fhir-works.json
           sed -i -e "s#AUTH_PASSWORD#$AUTH_PASSWORD#g" fhir-works.json
+          sed -i -e "s/okta-signin-username/input28/g" fhir-works.json
+          sed -i -e "s/okta-signin-password/input36/g" fhir-works.json
+          sed -i -e "s/okta-signin-submit/button-primary/g" fhir-works.json
+          sed -i -e "14 s/id/class/" fhir-works.json
           bundle exec rake db:create db:schema:load
           bundle exec rake inferno:execute_batch[fhir-works.json]
   custom-integration-tests:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The testing Okta deployment for CDK is a different version than with serverless, and hence the selectors used to input username/pw during the patient picker flow are different. This PR fixes that bug.

Tested by updating the selectors locally and running the inferno test suite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
