### PR TITLE
feat: Issue 676 order subscription sends in priority order to mitigat…

### DIFF
--- a/src/subscriptions/restHookLambda/restHook.test.ts
+++ b/src/subscriptions/restHookLambda/restHook.test.ts
@@ -20,6 +20,7 @@ jest.mock('../allowList', () => ({
 }));
 
 const getEvent = ({
+    approximateReceiveCount = '1',
     channelHeader = ['testKey:testValue'],
     channelPayload = 'application/fhir+json',
     endpoint = 'https://fake-end-point-1',
@@ -46,7 +47,7 @@ const getEvent = ({
                 }),
             }),
             attributes: {
-                ApproximateReceiveCount: '1',
+                ApproximateReceiveCount: approximateReceiveCount,
                 SentTimestamp: '123456789',
                 SenderId: 'FAKESENDERID',
                 MessageDeduplicationId: '1',
@@ -66,8 +67,62 @@ describe('Single tenant: Rest hook notification', () => {
     const allowListPromise: Promise<{ [key: string]: AllowListInfo }> = getAllowListInfo({ enableMultitenancy: false });
 
     beforeEach(() => {
-        axios.post = jest.fn().mockResolvedValueOnce({ data: { message: 'POST Successful' } });
-        axios.put = jest.fn().mockResolvedValueOnce({ data: { message: 'PUT Successful' } });
+        axios.post = jest.fn().mockReturnValue({ data: { message: 'POST Successful' } });
+        axios.put = jest.fn().mockReturnValue({ data: { message: 'PUT Successful' } });
+    });
+
+    test('Subscription Notifications sorted by endpoint+subscription ApproximateReceiveCount asc', async () => {
+        const subscriptionNotification1 = getEvent({
+            endpoint: 'https://fake-end-point-1',
+            approximateReceiveCount: '3',
+            channelHeader: ['order:3'],
+        }).Records[0];
+        const subscriptionNotification2 = getEvent({
+            endpoint: 'https://fake-end-point-1',
+            approximateReceiveCount: '2',
+            channelHeader: ['order:2'],
+        }).Records[0];
+        const subscriptionNotification3 = getEvent({
+            endpoint: 'https://fake-end-point-2/foo',
+            approximateReceiveCount: '25',
+            channelHeader: ['order:4'],
+        }).Records[0];
+        const subscriptionNotification4 = getEvent({
+            endpoint: 'https://fake-end-point-2/bar',
+            approximateReceiveCount: '1',
+            channelHeader: ['order:1'],
+        }).Records[0];
+
+        await expect(
+            restHookHandler.sendRestHookNotification(
+                {
+                    Records: [
+                        subscriptionNotification1,
+                        subscriptionNotification2,
+                        subscriptionNotification3,
+                        subscriptionNotification4,
+                    ],
+                },
+                allowListPromise,
+            ),
+        ).resolves.toMatchInlineSnapshot(`
+                    Object {
+                      "batchItemFailures": Array [],
+                    }
+                `);
+        expect(axios.put).toHaveBeenCalledTimes(4);
+        expect(axios.put).toHaveBeenNthCalledWith(1, 'https://fake-end-point-2/bar/Patient/1234567', null, {
+            headers: { 'header-name-2': ' header-value-2', order: '1' },
+        });
+        expect(axios.put).toHaveBeenNthCalledWith(2, 'https://fake-end-point-1/Patient/1234567', null, {
+            headers: { 'header-name-1': ' header-value-1', order: '2' },
+        });
+        expect(axios.put).toHaveBeenNthCalledWith(3, 'https://fake-end-point-1/Patient/1234567', null, {
+            headers: { 'header-name-1': ' header-value-1', order: '3' },
+        });
+        expect(axios.put).toHaveBeenNthCalledWith(4, 'https://fake-end-point-2/foo/Patient/1234567', null, {
+            headers: { 'header-name-2': ' header-value-2', order: '4' },
+        });
     });
 
     test('Empty POST notification is sent when channelPayload is null', async () => {


### PR DESCRIPTION
…e head of line blocking by bad endpoints

Issue #, if available:
Issue 676

Description of changes:
Added logic to order the batch of subscription notifications by distinct endpoint+subscription `ApproximateReceiveCount` sum. In a stateless manner tries to send subscription notifications that are more likely to succeed before sending subscription notifications that are more likely to fail.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [X] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
