### PR TITLE
test: add more negative integration tests

### DIFF
--- a/integration-tests/smartAuth.test.ts
+++ b/integration-tests/smartAuth.test.ts
@@ -25,7 +25,10 @@ async function searchPatient(client: AxiosInstance, name: string) {
 }
 
 test('Successfully read own user record and records that reference the user', async () => {
-    const fhirClient = await getFhirClient('launch/patient patient/Patient.read patient/Encounter.read profile openid', false);
+    const fhirClient = await getFhirClient(
+        'launch/patient patient/Patient.read patient/Encounter.read profile openid',
+        false,
+    );
 
     // Can look up own record
     const sherlockRecord = await getPatient(fhirClient, sherlockId);
@@ -127,7 +130,10 @@ describe('SMART AuthZ Negative tests', () => {
         });
     });
     test("ADMIN patient&system scope: Attempt to search for a Patient that doesn't reference the current user", async () => {
-        const fhirClient = await getFhirClient('launch/patient patient/Patient.read system/Patient.read profile openid', true);
+        const fhirClient = await getFhirClient(
+            'launch/patient patient/Patient.read system/Patient.read profile openid',
+            true,
+        );
         // In our configurations `system` scope does not have `search` operation permissions
         const getPatientAdmin = await searchPatient(fhirClient, 'Watson');
         expect(getPatientAdmin.data.total).toBe(0); // Should return no results

--- a/integration-tests/smartAuth.test.ts
+++ b/integration-tests/smartAuth.test.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from 'axios';
 import { getFhirClient, idsOfFhirResources, randomPatient } from './utils';
 
 const sherlockId = idsOfFhirResources.sherlockHolmes;
-const mycroftId = idsOfFhirResources.mycroftHolmes;
+const watsonId = idsOfFhirResources.johnWatson;
 
 async function getPatient(client: AxiosInstance, patientId: string) {
     const url = `/Patient/${patientId}`;
@@ -14,26 +14,31 @@ async function postPatient(client: AxiosInstance) {
     return client.post(url, randomPatient());
 }
 
-async function getEncounter(client: AxiosInstance, encounterId: string) {
-    const url = `/Encounter/${encounterId}`;
+async function searchEncounter(client: AxiosInstance, patientId: string) {
+    const url = `/Encounter/?subject=Patient/${patientId}`;
+    return client.get(url);
+}
+
+async function searchPatient(client: AxiosInstance, name: string) {
+    const url = `/Patient/?name=${name}`;
     return client.get(url);
 }
 
 test('Successfully read own user record and records that reference the user', async () => {
-    const fhirClient = await getFhirClient('launch/patient patient/Patient.read', false);
+    const fhirClient = await getFhirClient('launch/patient patient/Patient.read patient/Encounter.read profile openid', false);
 
+    // Can look up own record
     const sherlockRecord = await getPatient(fhirClient, sherlockId);
     expect(sherlockRecord.data.name[0].given).toEqual(['Sherlock']);
 
-    // Sherlock can read Mycroft's record because Mycroft has a reference to Sherlock
-    const mycroftRecord = await getPatient(fhirClient, mycroftId);
-    expect(mycroftRecord.data.name[0].given).toEqual(['Mycroft']);
+    const sherlockSearches = await searchPatient(fhirClient, 'Sherlock');
+    expect(sherlockSearches.data.total).toBeGreaterThan(0); // Should return 1+ results
 });
 
 describe('SMART AuthZ Negative tests', () => {
     test('Access token with insufficient scope', async () => {
         // FhirClient does not include enough permission because patient/Patient.read scope is missing
-        const fhirClient = await getFhirClient('launch/patient', false);
+        const fhirClient = await getFhirClient('launch/patient profile openid', false);
 
         await expect(getPatient(fhirClient, sherlockId)).rejects.toMatchObject({
             response: { status: 401 },
@@ -41,20 +46,10 @@ describe('SMART AuthZ Negative tests', () => {
     });
 
     test('Invalid access token', async () => {
-        const fhirClient = await getFhirClient('launch/patient patient/Patient.read', false, {
+        const fhirClient = await getFhirClient('launch/patient patient/Patient.read profile openid', false, {
             providedAccessToken: 'Invalid Access Token',
         });
         await expect(getPatient(fhirClient, sherlockId)).rejects.toMatchObject({
-            response: { status: 401 },
-        });
-    });
-
-    test("Failed to read record of a Patient that doesn't reference the current user", async () => {
-        const watsonId = idsOfFhirResources.johnWatson;
-        // FhirClient does not include enough permission because Watson doesn't have any reference to Sherlock
-        const fhirClient = await getFhirClient('launch/patient patient/Patient.read', false);
-
-        await expect(getPatient(fhirClient, watsonId)).rejects.toMatchObject({
             response: { status: 401 },
         });
     });
@@ -64,6 +59,35 @@ describe('SMART AuthZ Negative tests', () => {
         'user/Patient.read',
         'patient/Patient.read user/Patient.read',
     ];
+    describe.each(nonAdminScopes)('NON-ADMIN with scope: (%p)', (scope: string) => {
+        let fhirClient: AxiosInstance;
+
+        beforeAll(async () => {
+            fhirClient = await getFhirClient(`launch/patient fhirUser profile openid ${scope}`, false);
+        });
+        test('Attempt to SEARCH an encounter failing due to scope does not include Encounter', async () => {
+            await expect(searchEncounter(fhirClient, sherlockId)).rejects.toMatchObject({
+                response: { status: 401 },
+            });
+        });
+        test('Attempt to WRITE a Patient failing due to incorrect access scope', async () => {
+            await expect(postPatient(fhirClient)).rejects.toMatchObject({
+                response: { status: 401 },
+            });
+        });
+
+        test("Attempt to READ record of a Patient that doesn't reference the current user", async () => {
+            await expect(getPatient(fhirClient, watsonId)).rejects.toMatchObject({
+                response: { status: 401 },
+            });
+        });
+        test('Attempt to SEARCH an encounter failing due scope and user does not have a reference', async () => {
+            await expect(searchEncounter(fhirClient, watsonId)).rejects.toMatchObject({
+                response: { status: 401 },
+            });
+        });
+    });
+
     const adminScopes: string[] = [
         'patient/Patient.read',
         'user/Patient.read',
@@ -73,31 +97,14 @@ describe('SMART AuthZ Negative tests', () => {
         'system/Patient.read user/Patient.read',
         'patient/Patient.read system/Patient.read user/Patient.read',
     ];
-    describe.each(nonAdminScopes)('NON-ADMIN with scope: (%p)', (scope: string) => {
-        let fhirClient: AxiosInstance;
-
-        beforeAll(async () => {
-            fhirClient = await getFhirClient(`launch/patient fhirUser ${scope}`, false);
-        });
-        test('Attempt to READ an encounter failing due to scoped resource', async () => {
-            await expect(getEncounter(fhirClient, '1234')).rejects.toMatchObject({
-                response: { status: 401 },
-            });
-        });
-        test('Attempt to WRITE a Patient failing due to incorrect access scope', async () => {
-            await expect(postPatient(fhirClient)).rejects.toMatchObject({
-                response: { status: 401 },
-            });
-        });
-    });
     describe.each(adminScopes)('ADMIN with scope: (%p)', (scope: string) => {
         let fhirClient: AxiosInstance;
 
         beforeAll(async () => {
-            fhirClient = await getFhirClient(`launch/patient fhirUser ${scope}`, true);
+            fhirClient = await getFhirClient(`launch/patient fhirUser profile openid ${scope}`, true);
         });
-        test('Attempt to READ an encounter failing due to scoped resource', async () => {
-            await expect(getEncounter(fhirClient, '1234')).rejects.toMatchObject({
+        test('Attempt to SEARCH an encounter failing due to scoped resource', async () => {
+            await expect(searchEncounter(fhirClient, sherlockId)).rejects.toMatchObject({
                 response: { status: 401 },
             });
         });
@@ -106,5 +113,23 @@ describe('SMART AuthZ Negative tests', () => {
                 response: { status: 401 },
             });
         });
+        test('Attempt to SEARCH an encounter failing due scope and user does not have a reference', async () => {
+            await expect(searchEncounter(fhirClient, watsonId)).rejects.toMatchObject({
+                response: { status: 401 },
+            });
+        });
+    });
+    test("ADMIN patient scope: Failed to read record of a Patient that doesn't reference the current user", async () => {
+        const fhirClient = await getFhirClient('launch/patient patient/Patient.read profile openid', true);
+        // This is getting the launch/patient as Dr. Bell he does not have access to Watson's records
+        await expect(getPatient(fhirClient, watsonId)).rejects.toMatchObject({
+            response: { status: 401 },
+        });
+    });
+    test("ADMIN patient&system scope: Search for a Patient that doesn't reference the current user", async () => {
+        const fhirClient = await getFhirClient('launch/patient patient/Patient.read system/Patient.read profile openid', true);
+        // In our configurations `system` scope does not have `search` operation permissions
+        const getPatientAdmin = await searchPatient(fhirClient, 'Watson');
+        expect(getPatientAdmin.data.total).toBe(0); // Should return no results
     });
 });

--- a/integration-tests/smartAuth.test.ts
+++ b/integration-tests/smartAuth.test.ts
@@ -119,14 +119,14 @@ describe('SMART AuthZ Negative tests', () => {
             });
         });
     });
-    test("ADMIN patient scope: Failed to read record of a Patient that doesn't reference the current user", async () => {
+    test("ADMIN patient scope: Attempt to read record of a Patient that doesn't reference the current user", async () => {
         const fhirClient = await getFhirClient('launch/patient patient/Patient.read profile openid', true);
         // This is getting the launch/patient as Dr. Bell he does not have access to Watson's records
         await expect(getPatient(fhirClient, watsonId)).rejects.toMatchObject({
             response: { status: 401 },
         });
     });
-    test("ADMIN patient&system scope: Search for a Patient that doesn't reference the current user", async () => {
+    test("ADMIN patient&system scope: Attempt to search for a Patient that doesn't reference the current user", async () => {
         const fhirClient = await getFhirClient('launch/patient patient/Patient.read system/Patient.read profile openid', true);
         // In our configurations `system` scope does not have `search` operation permissions
         const getPatientAdmin = await searchPatient(fhirClient, 'Watson');

--- a/integration-tests/smartAuth.test.ts
+++ b/integration-tests/smartAuth.test.ts
@@ -1,11 +1,21 @@
 import { AxiosInstance } from 'axios';
-import { getFhirClient, idsOfFhirResources } from './utils';
+import { getFhirClient, idsOfFhirResources, randomPatient } from './utils';
 
 const sherlockId = idsOfFhirResources.sherlockHolmes;
 const mycroftId = idsOfFhirResources.mycroftHolmes;
 
 async function getPatient(client: AxiosInstance, patientId: string) {
     const url = `/Patient/${patientId}`;
+    return client.get(url);
+}
+
+async function postPatient(client: AxiosInstance) {
+    const url = '/Patient/';
+    return client.post(url, randomPatient());
+}
+
+async function getEncounter(client: AxiosInstance, encounterId: string) {
+    const url = `/Encounter/${encounterId}`;
     return client.get(url);
 }
 
@@ -20,7 +30,7 @@ test('Successfully read own user record and records that reference the user', as
     expect(mycroftRecord.data.name[0].given).toEqual(['Mycroft']);
 });
 
-describe('Negative tests', () => {
+describe('SMART AuthZ Negative tests', () => {
     test('Access token with insufficient scope', async () => {
         // FhirClient does not include enough permission because patient/Patient.read scope is missing
         const fhirClient = await getFhirClient('launch/patient', false);
@@ -46,6 +56,55 @@ describe('Negative tests', () => {
 
         await expect(getPatient(fhirClient, watsonId)).rejects.toMatchObject({
             response: { status: 401 },
+        });
+    });
+
+    const nonAdminScopes: string[] = [
+        'patient/Patient.read',
+        'user/Patient.read',
+        'patient/Patient.read user/Patient.read',
+    ];
+    const adminScopes: string[] = [
+        'patient/Patient.read',
+        'user/Patient.read',
+        'system/Patient.read',
+        'patient/Patient.read user/Patient.read',
+        'patient/Patient.read system/Patient.read',
+        'system/Patient.read user/Patient.read',
+        'patient/Patient.read system/Patient.read user/Patient.read',
+    ];
+    describe.each(nonAdminScopes)('NON-ADMIN with scope: (%p)', (scope: string) => {
+        let fhirClient: AxiosInstance;
+
+        beforeAll(async () => {
+            fhirClient = await getFhirClient(`launch/patient fhirUser ${scope}`, false);
+        });
+        test('Attempt to READ an encounter failing due to scoped resource', async () => {
+            await expect(getEncounter(fhirClient, '1234')).rejects.toMatchObject({
+                response: { status: 401 },
+            });
+        });
+        test('Attempt to WRITE a Patient failing due to incorrect access scope', async () => {
+            await expect(postPatient(fhirClient)).rejects.toMatchObject({
+                response: { status: 401 },
+            });
+        });
+    });
+    describe.each(adminScopes)('ADMIN with scope: (%p)', (scope: string) => {
+        let fhirClient: AxiosInstance;
+
+        beforeAll(async () => {
+            fhirClient = await getFhirClient(`launch/patient fhirUser ${scope}`, true);
+        });
+        test('Attempt to READ an encounter failing due to scoped resource', async () => {
+            await expect(getEncounter(fhirClient, '1234')).rejects.toMatchObject({
+                response: { status: 401 },
+            });
+        });
+        test('Attempt to WRITE a Patient failing due to incorrect access scope', async () => {
+            await expect(postPatient(fhirClient)).rejects.toMatchObject({
+                response: { status: 401 },
+            });
         });
     });
 });


### PR DESCRIPTION
Description of changes:
- Covering insufficient resource scope test
- Covering insufficient action scope test
- Covering insufficient reference
- Covering insufficient scope+reference

Test output:
```sh
  PASS  integration-tests/smartAuth.test.ts (19.172 s)
  ✓ Successfully read own user record and records that reference the user (1241 ms)
  SMART AuthZ Negative tests
    ✓ Access token with insufficient scope (870 ms)
    ✓ Invalid access token (165 ms)
    ✓ ADMIN patient scope: Failed to read record of a Patient that doesn't reference the current user (918 ms)
    ✓ ADMIN patient&system scope: Search for a Patient that doesn't reference the current user (881 ms)
    NON-ADMIN with scope: ("patient/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scope does not include Encounter (166 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (166 ms)
      ✓ Attempt to READ record of a Patient that doesn't reference the current user (215 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (174 ms)
    NON-ADMIN with scope: ("user/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scope does not include Encounter (160 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (162 ms)
      ✓ Attempt to READ record of a Patient that doesn't reference the current user (175 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (132 ms)
    NON-ADMIN with scope: ("patient/Patient.read user/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scope does not include Encounter (140 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (162 ms)
      ✓ Attempt to READ record of a Patient that doesn't reference the current user (167 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (133 ms)
    ADMIN with scope: ("patient/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scoped resource (158 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (164 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (131 ms)
    ADMIN with scope: ("user/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scoped resource (127 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (167 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (131 ms)
    ADMIN with scope: ("system/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scoped resource (177 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (142 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (136 ms)
    ADMIN with scope: ("patient/Patient.read user/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scoped resource (145 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (142 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (157 ms)
    ADMIN with scope: ("patient/Patient.read system/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scoped resource (133 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (134 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (152 ms)
    ADMIN with scope: ("system/Patient.read user/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scoped resource (165 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (128 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (132 ms)
    ADMIN with scope: ("patient/Patient.read system/Patient.read user/Patient.read")
      ✓ Attempt to SEARCH an encounter failing due to scoped resource (143 ms)
      ✓ Attempt to WRITE a Patient failing due to incorrect access scope (134 ms)
      ✓ Attempt to SEARCH an encounter failing due scope and user does not have a reference (130 ms)
```

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
